### PR TITLE
chore: Remove `publish_android` input from Multi-Platform Build & Publish Workflow

### DIFF
--- a/.github/workflows/multi-platform-build-and-publish.yaml
+++ b/.github/workflows/multi-platform-build-and-publish.yaml
@@ -59,7 +59,6 @@
 # - ios_package_name: Name of iOS module
 # - desktop_package_name: Name of desktop module
 # - web_package_name: Name of web module
-# - publish_android: Enable/disable Android Play Store publishing
 # - build_ios: Enable/disable iOS build
 # - publish_ios: Enable/disable iOS App Store publishing
 # - tester_groups: Firebase tester group for distribution
@@ -109,11 +108,6 @@ on:
         description: 'Name of the Web project module'
         type: string
         required: true
-
-      publish_android:
-        type: boolean
-        default: false
-        description: Publish Android App On Play Store
 
       build_ios:
         type: boolean
@@ -250,7 +244,6 @@ jobs:
   # Publish Android app on Play Store
   publish_android_on_playstore:
     name: Publish Android App On Play Store
-    if: inputs.publish_android
     runs-on: macos-latest
     steps:
       # Check out caller repository


### PR DESCRIPTION
Removed the `publish_android` input from the workflow, as it's no longer needed. This change simplifies the workflow configuration.