### PR TITLE
Update pr-check.yaml

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -108,6 +108,12 @@ on:
         description: 'Name of the iOS project module'
         type: string
         required: true
+        
+      build_ios:
+        description: 'Build iOS Application'
+        type: boolean
+        required: false  
+        default: true
 
 # Concurrency settings to prevent multiple simultaneous workflow runs
 concurrency:
@@ -179,4 +185,5 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build iOS App
+        if: ${{ inputs.build_ios }}
         uses: openMF/kmp-build-ios-app-action@v1.0.0


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to add support for optionally building the iOS application. The most important changes include adding a new input parameter and conditional execution of the iOS build job.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/pr-check.yaml`](diffhunk://#diff-4af6e335dbc6aa6244230fe2bdf9a37805bd010654719996e5ab6a4716a5f247R112-R117): Added a new input parameter `build_ios` to optionally build the iOS application. This parameter is a boolean, not required, and defaults to `true`.
* [`.github/workflows/pr-check.yaml`](diffhunk://#diff-4af6e335dbc6aa6244230fe2bdf9a37805bd010654719996e5ab6a4716a5f247R188): Modified the iOS build job to run conditionally based on the value of the `build_ios` input parameter.