### PR TITLE
feat: Add Android Build and Publish Workflow

### DIFF
--- a/.github/workflows/android-build-and-publish.yaml
+++ b/.github/workflows/android-build-and-publish.yaml
@@ -1,0 +1,276 @@
+# GitHub Actions Workflow for Android Application Deployment
+#
+# OVERVIEW:
+# This workflow supports building and publishing applications across multiple platforms:
+# - Android (APK/AAB)
+#
+# PREREQUISITES:
+# 1. Ensure your project is configured with:
+#    - Gradle build system
+#    - Fastlane for deployment automation
+#    - Separate modules/package names for each platform
+#
+# REQUIRED SECRETS:
+# Configure the following secrets in GitHub repository settings:
+#
+# Android-related secrets:
+# - original_keystore_file: Base64 encoded Android release keystore
+# - original_keystore_file_password: Keystore password
+# - original_keystore_alias: Keystore alias
+# - original_keystore_alias_password: Keystore alias password
+#
+# - upload_keystore_file: Base64 encoded Android upload keystore
+# - upload_keystore_file_password: Upload keystore password
+# - upload_keystore_alias: Upload keystore alias
+# - upload_keystore_alias_password: Upload keystore alias password
+#
+# Google and Firebase credentials:
+# - google_services: Google Services configuration JSON
+# - playstore_creds: Play Store service account credentials
+# - firebase_creds: Firebase distribution credentials
+# - token: GitHub token for repository access
+#
+
+# WORKFLOW INPUTS:
+# - release_type: 'internal' (default) or 'beta'
+# - target_branch: Branch to use for release (default: 'dev')
+# - android_package_name: Name of Android module
+# - tester_groups: Firebase tester group for distribution
+
+# USAGE:
+# 1. Ensure all required secrets are configured
+# 2. Customize package names in workflow inputs
+# 3. Toggle platform-specific publishing flags
+# 4. Trigger workflow manually or via GitHub Actions UI
+
+# NOTES:
+# - Some TODO sections exist for future implementation
+# - Requires Fastlane and specific project structure
+# - Assumes Kotlin Multiplatform or similar cross-platform setup
+
+name: Android App Build and Publish
+
+on:
+  workflow_call:
+    inputs:
+      release_type:
+        type: string
+        default: 'internal'
+        description: Release Type
+
+      target_branch:
+        type: string
+        default: 'dev'
+        description: 'Target branch for release'
+
+      android_package_name:
+        description: 'Name of the Android project module'
+        type: string
+        required: true
+
+      tester_groups:
+        type: string
+        description: 'Firebase Tester Group'
+        required: true
+
+    secrets:
+      # Android-related secrets
+      original_keystore_file:
+        description: 'Base64 encoded Android release keystore'
+        required: false
+      original_keystore_file_password:
+        description: 'Keystore password'
+        required: false
+      original_keystore_alias:
+        description: 'Keystore alias'
+        required: false
+      original_keystore_alias_password:
+        description: 'Keystore alias password'
+        required: false
+
+      upload_keystore_file:
+        description: 'Base64 encoded Android upload keystore'
+        required: false
+      upload_keystore_file_password:
+        description: 'Upload keystore password'
+        required: false
+      upload_keystore_alias:
+        description: 'Upload keystore alias'
+        required: false
+      upload_keystore_alias_password:
+        description: 'Upload keystore alias password'
+        required: false
+
+      # Google and Firebase credentials
+      google_services:
+        description: 'Google Services configuration JSON'
+        required: false
+      playstore_creds:
+        description: 'Play Store service account credentials'
+        required: false
+      firebase_creds:
+        description: 'Firebase distribution credentials'
+        required: false
+      token:
+        description: 'Github Token'
+        required: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Publish Android app on Firebase App Distribution
+  publish_android_on_firebase:
+    name: Deploy Android App On Firebase
+    runs-on: macos-latest
+    steps:
+      # Check out caller repository
+      - name: Checkout Caller Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Publish Android App on Firebase
+        uses: openMF/kmp-android-firebase-publish-action@v2.0.0
+        with:
+          android_package_name: ${{ inputs.android_package_name }}
+          keystore_file: ${{ secrets.original_keystore_file }}
+          keystore_password: ${{ secrets.original_keystore_file_password }}
+          keystore_alias: ${{ secrets.original_keystore_alias }}
+          keystore_alias_password: ${{ secrets.original_keystore_alias_password }}
+          google_services: ${{ secrets.google_services }}
+          firebase_creds: ${{ secrets.firebase_creds }}
+          tester_groups: ${{ inputs.tester_groups }}
+
+  # Creates GitHub release with all built artifacts
+  github_release:
+    name: Create Github Release
+    needs: [ publish_android_on_firebase ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Generate Release Number
+      - name: Generate Release Number
+        id: rel_number
+        shell: bash
+        run: |        
+          set +e  # Disable exit on error to handle task non-existence
+          ./gradlew versionFile
+          VERSIONFILE_EXIT_CODE=$?
+          set -e  # Re-enable exit on error
+          
+          # Check if version file exists after attempting to generate it
+          if [ -f "version.txt" ]; then
+          echo "Using version from versionFile"
+          VERSION=$(cat version.txt)
+
+          # Count commits to generate version code
+          VERSION_CODE=$(($(git rev-list --count HEAD) * 10))
+
+          echo "Version from file: ${VERSION}"
+          echo "Version Code: ${VERSION_CODE}"
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version-code=${VERSION_CODE}" >> $GITHUB_OUTPUT
+          exit 0
+          fi
+          
+          # Fallback to Git-based version generation
+          # Get the latest tag or use 1.0.0 as default
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+          
+          # Remove 'v' prefix if present
+          LATEST_TAG=${LATEST_TAG#v}
+          
+          # Count commits since the last tag
+          COMMITS_SINCE_TAG=$(git rev-list ${LATEST_TAG}..HEAD --count)
+          
+          # Extract major, minor, patch from the latest tag
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST_TAG}"
+          
+          # Increment patch version and add commits as build number
+          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          
+          # Calculate version code (can be adjusted based on your versioning needs)
+          VERSION_CODE=$(($(git rev-list --count HEAD) * 10))
+          
+          echo "Version: ${NEW_VERSION}"
+          echo "Version Code: ${VERSION_CODE}"
+          
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+
+      - name: Generate Release Notes
+        uses: actions/github-script@v7
+        id: release-notes
+        with:
+          github-token: ${{ secrets.token }}
+          script: |
+            try {
+              // Get latest release tag
+              const latestRelease = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              const previousTag = latestRelease.data.tag_name;
+
+              // Generate release notes
+              const params = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: '${{ steps.rel_number.outputs.version }}',
+                target_commitish: '${{ inputs.target_branch }}'
+              };
+
+              const { data } = await github.rest.repos.generateReleaseNotes(params);
+              const changelog = data.body.replaceAll('`', '\'').replaceAll('"', '\'');
+
+              // Write changelog files
+              const fs = require('fs');
+              fs.writeFileSync('changelogGithub', changelog);
+
+              // Generate beta changelog
+              const { execSync } = require('child_process');
+              execSync('git log --format="* %s" HEAD^..HEAD > changelogBeta');
+
+              return changelog;
+            } catch (error) {
+              console.error('Error generating release notes:', error);
+              return '';
+            }
+
+      # Get all build artifacts
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./all-artifacts
+
+      # Debug: Show downloaded files
+      - name: Display structure of downloaded files
+        run: ls -R ./all-artifacts
+
+      #Creates a ZIP archive of the web app build using PowerShell.
+      - name: Archive Web Build
+        shell: pwsh
+        # Executes the Compress-Archive command to create the ZIP archive.
+        run: |
+          Compress-Archive -Path './all-artifacts/web-app/*' -DestinationPath './all-artifacts/${{ inputs.web_package_name }}.zip'
+
+      # Create GitHub pre-release with all artifacts
+      - name: Create Github Pre-Release
+        uses: softprops/action-gh-release@v2.0.8
+        with:
+          tag_name: ${{ steps.rel_number.outputs.version }}
+          body_path: ./changelogGithub
+          draft: false
+          prerelease: true
+          files: |
+            ./all-artifacts/android-app/${{ inputs.android_package_name }}/build/outputs/apk/demo/release/*.apk
+            ./all-artifacts/android-app/${{ inputs.android_package_name }}/build/outputs/apk/prod/release/*.apk


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and publishing an Android application. The workflow includes steps for deploying the app on Firebase and creating a GitHub release with the built artifacts.

### New Workflow for Android Application Deployment:

* Added a comprehensive GitHub Actions workflow configuration file `.github/workflows/android-build-and-publish.yaml` to support building and publishing Android applications.

### Key Features:

* **Workflow Inputs and Secrets:**
  - Defined inputs for release type, target branch, Android package name, and Firebase tester groups.
  - Configured required secrets for Android keystore files, Google services, Play Store, Firebase credentials, and GitHub token.

* **Job for Firebase Distribution:**
  - Added a job to deploy the Android app on Firebase using the `openMF/kmp-android-firebase-publish-action@v2.0.0` action.

* **Job for GitHub Release:**
  - Added a job to create a GitHub release, including steps for generating release numbers, release notes, downloading artifacts, and creating a pre-release with all built artifacts.