### PR TITLE
feat: Added Play Store Publish Action

### DIFF
--- a/.github/workflows/android-build-and-publish.yaml
+++ b/.github/workflows/android-build-and-publish.yaml
@@ -146,6 +146,29 @@ jobs:
           firebase_creds: ${{ secrets.firebase_creds }}
           tester_groups: ${{ inputs.tester_groups }}
 
+  # Publish Android app on Play Store
+  publish_android_on_playstore:
+    name: Publish Android App On Play Store
+    runs-on: macos-latest
+    steps:
+      # Check out caller repository
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Promote Android App to Beta or Internal
+        uses: openMF/kmp-publish-android-on-playstore-beta-action@v1.0.0
+        with:
+          release_type: ${{ inputs.release_type }}
+          android_package_name: ${{ inputs.android_package_name }}
+          google_services: ${{ secrets.google_services }}
+          playstore_creds: ${{ secrets.playstore_creds }}
+          keystore_file: ${{ secrets.upload_keystore_file }}
+          keystore_password: ${{ secrets.upload_keystore_file_password }}
+          keystore_alias: ${{ secrets.upload_keystore_alias }}
+          keystore_alias_password: ${{ secrets.upload_keystore_alias_password }}
+
   # Creates GitHub release with all built artifacts
   github_release:
     name: Create Github Release


### PR DESCRIPTION
This pull request includes a significant addition to the `.github/workflows/android-build-and-publish.yaml` file to automate the publishing of the Android app on the Play Store. The most important change is the introduction of a new job to the GitHub Actions workflow.

New job added to the GitHub Actions workflow:

* [`publish_android_on_playstore`](diffhunk://#diff-19db4c9d878fd3cbb254433d0af803ae1020e98ea8c4efe925e8e68707a45f71R149-R171): A new job named "Publish Android App On Play Store" was added to automate the process of promoting the Android app to Beta or Internal channels on the Play Store. This job checks out the repository and uses the `openMF/kmp-publish-android-on-playstore-beta-action@v1.0.0` action to handle the promotion, utilizing various secrets and inputs for configuration.