### PR TITLE
Fix: Set output for generateVersion step

### DIFF
--- a/.github/workflows/android-build-and-publish.yaml
+++ b/.github/workflows/android-build-and-publish.yaml
@@ -232,7 +232,8 @@ jobs:
       # Generate Version
       - name: Generate Version
         id: rel_number
-        run: bundle exec fastlane android generateVersion
+        run: |
+          echo "version=$(bundle exec fastlane android generateVersion | grep VERSION= | cut -d'=' -f2)" >> $GITHUB_OUTPUT
 
       - name: Generate Release Notes
         id: release_notes

--- a/.github/workflows/multi-platform-build-and-publish.yaml
+++ b/.github/workflows/multi-platform-build-and-publish.yaml
@@ -399,7 +399,8 @@ jobs:
       # Generate Version
       - name: Generate Version
         id: rel_number
-        run: bundle exec fastlane android generateVersion
+        run: |
+          echo "version=$(bundle exec fastlane android generateVersion | grep VERSION= | cut -d'=' -f2)" >> $GITHUB_OUTPUT
 
       - name: Generate Release Notes
         id: release_notes


### PR DESCRIPTION
The `generateVersion` step in the Android and Multi-platform build and publish workflows was not setting the output correctly.

This commit fixes the issue by:

- Adding a command to the `run` section of the `generateVersion` step that extracts the version number from the output of the `fastlane android generateVersion` command and sets it as an output variable named `version`.
- This allows subsequent steps in the workflow to access the generated version number.