### PR TITLE
chore: Removed `--confirm` flag from `gh cache delete`

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -62,7 +62,7 @@ jobs:
           
           # Delete each cache
           for KEY in $CACHE_KEYS; do
-            gh cache delete $KEY -R $REPO -B $BRANCH --confirm
+            gh cache delete $KEY -R $REPO -B $BRANCH
             echo "Deleted cache: $KEY"
           done
           
@@ -79,7 +79,7 @@ jobs:
       - name: Cleanup All Caches
         run: |
           echo "Cleaning all repository caches..."
-          gh cache delete --all -R $REPO --confirm
+          gh cache delete --all -R $REPO
           echo "All caches cleaned up"
         env:
           REPO: ${{ github.repository }}


### PR DESCRIPTION
Removed the `--confirm` flag from the `gh cache delete` command in the `cache-cleanup` workflow to avoid manual confirmation and automate cache deletion.