### PR TITLE
Automate GitHub Secrets Verification and Creation

### DIFF
--- a/.github/workflows/verify-secrets.sh
+++ b/.github/workflows/verify-secrets.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# REQUIRED ENV VARS:
+# GITHUB_TOKEN
+# TARGET=repo|org
+# OWNER
+# REPO (required if TARGET=repo)
+# SECRET_NAME
+# SECRET_VALUE
+
+API="https://api.github.com"
+AUTH="Authorization: token $GITHUB_TOKEN"
+ACCEPT="Accept: application/vnd.github+json"
+
+echo "Checking secret: $SECRET_NAME"
+
+if [[ "$TARGET" == "repo" ]]; then
+  BASE="$API/repos/$OWNER/$REPO/actions/secrets"
+elif [[ "$TARGET" == "org" ]]; then
+  BASE="$API/orgs/$OWNER/actions/secrets"
+else
+  echo "TARGET must be 'repo' or 'org'"
+  exit 1
+fi
+
+# Fetch public key
+pk_response=$(curl -s -H "$AUTH" -H "$ACCEPT" "$BASE/public-key")
+key_id=$(echo "$pk_response" | jq -r '.key_id')
+public_key=$(echo "$pk_response" | jq -r '.key')
+
+if [[ -z "$key_id" || -z "$public_key" || "$key_id" == "null" ]]; then
+  echo "Failed to fetch public key"
+  exit 1
+fi
+
+# Check if secret exists
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "$AUTH" "$BASE/$SECRET_NAME")
+
+if [[ "$status" == "200" ]]; then
+  echo "Secret '$SECRET_NAME' already exists"
+  exit 0
+fi
+
+echo "Secret missing, creating..."
+
+# Encrypt secret 
+encrypted_value=$(python3 - <<EOF
+import base64
+from nacl import encoding, public
+
+pk = public.PublicKey("$public_key".encode(), encoding.Base64Encoder())
+sealed_box = public.SealedBox(pk)
+encrypted = sealed_box.encrypt("$SECRET_VALUE".encode())
+print(base64.b64encode(encrypted).decode())
+EOF
+)
+
+#  Create secret
+curl -s -X PUT \
+  -H "$AUTH" \
+  -H "$ACCEPT" \
+  "$BASE/$SECRET_NAME" \
+  -d "{\"encrypted_value\":\"$encrypted_value\",\"key_id\":\"$key_id\"}"
+
+echo "Secret '$SECRET_NAME' added successfully"

--- a/.github/workflows/verify-secrets.yml
+++ b/.github/workflows/verify-secrets.yml
@@ -1,0 +1,45 @@
+name: Verify & Create GitHub Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "repo or org"
+        required: true
+        default: "repo"
+      secret_name:
+        description: "Secret name"
+        required: true
+
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq python3 python3-pip
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pynacl
+
+      - name: Verify / create secret
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ inputs.target }}
+          OWNER: Nightwing-77
+          REPO: mifos-x-actionhub
+          SECRET_NAME: ${{ inputs.secret_name }}
+          SECRET_VALUE: ${{ secrets.SECRET_VALUE_TO_SYNC }}
+        run: |
+          chmod +x .github/workflows/verify-secrets.sh
+          .github/workflows/verify-secrets.sh


### PR DESCRIPTION
Jira Ticket: [KMPPT-29] 
GitHub Issue: [#30 ]

Added .github/workflows/verify-secrets.yml to automate the verification and creation of GitHub secrets.

Created verify-secrets.sh as a wrapper script for the workflow.

Workflow functionality includes:

Checking if a secret exists in a repository or organization.

Encrypting secrets using the GitHub public key.

Creating the secret if it is missing.

Workflow dispatch supports target (repo/org) and secret_name inputs.

Squashed multiple commits into a single clean commit for clarity.

[KMPPT-29]: https://mifosforge.jira.com/browse/KMPPT-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ