### PR TITLE
feat(workflows): add reusable test-coverage gate for KMP / Kover projects

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,88 @@
+# Reusable test-coverage workflow for Kover-based KMP / multi-module projects.
+#
+# Consumers call this via
+#   uses: openMF/mifos-x-actionhub/.github/workflows/test-coverage.yaml@<ref>
+#
+# Internally delegates to the composite action
+#   MobileByteLabs/mifos-x-actionhub-kover-coverage@v1
+# which holds the actual logic (kover XML report run + per-module floor
+# check) — same delegation pattern every other workflow in this umbrella
+# uses for its sibling `mifos-x-actionhub-*` composite actions.
+#
+# Discovery is fully dynamic: whatever modules apply the Kover plugin (via
+# a convention plugin or direct application) emit `build/reports/kover/report.xml`,
+# and the composite action checks each against `.kover-floor.yml`. Adding
+# a new module to a consumer fork needs zero workflow changes.
+
+name: Test Coverage Floor (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: 'JDK version to set up before running Gradle.'
+        type: string
+        default: '17'
+      java-distribution:
+        description: 'JDK distribution (temurin, zulu, etc.).'
+        type: string
+        default: 'temurin'
+      report-task:
+        description: 'Gradle task that produces the per-module kover XML reports.'
+        type: string
+        default: 'koverXmlReport'
+      gradle-args:
+        description: 'Extra Gradle args appended to the report task invocation.'
+        type: string
+        default: '--continue --stacktrace'
+      floor-file:
+        description: 'Path (relative to repo root) of the per-module floor YAML.'
+        type: string
+        default: '.kover-floor.yml'
+      default-floor:
+        description: 'Line-coverage floor (%) for any module not listed in the floor file.'
+        type: number
+        default: 0
+      upload-html-report:
+        description: 'Whether to upload the aggregated HTML coverage report as an artifact.'
+        type: boolean
+        default: true
+      html-report-path:
+        description: 'Path of the aggregated HTML report directory (project-specific override).'
+        type: string
+        default: 'build/reports/kover/html'
+      artifact-retention-days:
+        description: 'Retention in days for the uploaded HTML coverage artifact.'
+        type: number
+        default: 14
+      runs-on:
+        description: 'Runner label.'
+        type: string
+        default: 'ubuntu-latest'
+      timeout-minutes:
+        description: 'Job timeout in minutes.'
+        type: number
+        default: 45
+
+jobs:
+  coverage:
+    name: Enforce per-module coverage floor
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Kover coverage gate
+        uses: MobileByteLabs/mifos-x-actionhub-kover-coverage@v1
+        with:
+          java-version: ${{ inputs.java-version }}
+          java-distribution: ${{ inputs.java-distribution }}
+          report-task: ${{ inputs.report-task }}
+          gradle-args: ${{ inputs.gradle-args }}
+          floor-file: ${{ inputs.floor-file }}
+          default-floor: ${{ inputs.default-floor }}
+          upload-html-report: ${{ inputs.upload-html-report }}
+          html-report-path: ${{ inputs.html-report-path }}
+          artifact-retention-days: ${{ inputs.artifact-retention-days }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/test-coverage.yaml` — a reusable workflow that enforces per-module Kover line-coverage floors on KMP / multi-module Kotlin projects.

**Architecture: this umbrella workflow delegates to the composite action at [MobileByteLabs/mifos-x-actionhub-kover-coverage@v1](https://github.com/MobileByteLabs/mifos-x-actionhub-kover-coverage)** — same delegation pattern this repo already uses for every other `mifos-x-actionhub-*` sibling (`mifos-x-actionhub-static-analysis-check`, `mifos-x-actionhub-build-*`, `mifos-x-actionhub-publish-*`, etc).

Consumers call this as:

```yaml
jobs:
  coverage:
    uses: openMF/mifos-x-actionhub/.github/workflows/test-coverage.yaml@v1.0.12
    with:
      default-floor: 0
```

## Why

KMP projects in the openMF org are starting to wire Kover (see `openMF/kmp-project-template` PR #153 which merged the kover infrastructure, and PR #155 which lands the audit + cutover to this workflow). Without a reusable gate, every consumer maintains the same ~200 lines of workflow + Python checker. This PR consolidates that into one entry point in the actionhub umbrella, with the actual logic in a sibling composite action.

## Architecture

```
                                                  ┌──────────────────────────────────────────┐
consumer repo                                     │  composite action (the engine)            │
.github/workflows/test-coverage.yml ───┐          │  MobileByteLabs/mifos-x-actionhub-         │
   uses: openMF/mifos-x-actionhub/     │          │     kover-coverage@v1                       │
        .github/workflows/             │          │   - action.yaml                            │
        test-coverage.yaml@v1.0.12     ▼          │   - scripts/check-coverage-floor.py        │
                                                  │   - 9 inputs, 4 steps                      │
THIS PR  ──── .github/workflows/test-coverage.yaml│   (setup-java, setup-gradle,               │
                workflow_call →                   │    ./gradlew koverXmlReport,               │
                  job 'coverage' →                │    floor check, HTML artifact upload)      │
                    step 'uses: MobileByteLabs/  ─┘
                          mifos-x-actionhub-kover-coverage@v1'
```

The umbrella workflow is a 90-line passthrough — all inputs forwarded to the composite action. Logic + script live in one place (the composite action repo). Identical layout to how the rest of this umbrella wraps its siblings.

## Design highlights

**Fully dynamic module discovery.** No `module-paths` input, no hardcoded module list, no path filter. Whatever modules apply the Kover plugin (via a convention plugin or direct application) emit `build/reports/kover/report.xml`, and the composite action checks every one against `.kover-floor.yml` in the consumer repo. New modules added to a consumer fork participate automatically.

**Two-tier floor model.**
- `default-floor` workflow input applies globally (defaults to 0)
- `.kover-floor.yml` in the consumer repo carries per-module overrides only

**Failure modes.**

| Condition | Result |
|---|---|
| actual < floor | ❌ hard fail (regression) |
| listed module + no `report.xml` + floor > default | ❌ hard fail (build broke before tests, or floor file out of sync) |
| listed module at default with no report | ⚠️ warn (stale entry) |
| module not listed | uses `default-floor` |

## Workflow inputs

All optional with sensible defaults; forwarded 1:1 to the composite action:

| Input | Default | Purpose |
|---|---|---|
| `java-version` | `'17'` | JDK version |
| `java-distribution` | `'temurin'` | JDK distribution |
| `report-task` | `'koverXmlReport'` | Gradle task name |
| `gradle-args` | `'--continue --stacktrace'` | Extra args |
| `floor-file` | `'.kover-floor.yml'` | Repo-relative floor path |
| `default-floor` | `0` | Default floor for unlisted modules |
| `upload-html-report` | `true` | Upload aggregated HTML as artifact |
| `html-report-path` | `'build/reports/kover/html'` | HTML report dir |
| `artifact-retention-days` | `14` | Artifact retention |
| `runs-on` | `'ubuntu-latest'` | Runner label |
| `timeout-minutes` | `45` | Job timeout |

## Files

This PR is one file:
- `.github/workflows/test-coverage.yaml` — the reusable workflow (88 lines, well-commented)

The Python checker + the actual `setup-java → koverXmlReport → floor check → artifact upload` steps live in the composite action — they are NOT duplicated here.

## Companion PRs

- `openMF/kmp-project-template` PR #153 — kover infrastructure (already merged)
- `openMF/kmp-project-template` PR #155 — audit + cutover, references `openMF/mifos-x-actionhub/.github/workflows/test-coverage.yaml@main` for now; will pin to the next actionhub tag once this PR merges.

## Test plan

- [x] Workflow YAML syntax-valid
- [x] Composite action smoke-tested against partial Kover reports — soft/hard failure separation correct
- [ ] First end-to-end CI run: `openMF/kmp-project-template` PR #155 (pinned to `@main` until this PR lands and a tag is cut)
- [ ] Maintainer cuts a release tag (`v1.0.12`?) — I'll update PR #155 to pin to that tag

## Maintainer note

Once merged, please cut the next release tag (latest is `v1.0.11`) and let me know — I'll bump `openMF/kmp-project-template` PR #155 from `@main` to that tag.