### PR TITLE
fix(ci): bump default xcode-version 16.4 → 26.0 for iOS 26 SDK

### DIFF
--- a/.github/workflows/multi-platform-build-and-publish.yaml
+++ b/.github/workflows/multi-platform-build-and-publish.yaml
@@ -101,9 +101,14 @@ on:
         type: string
 
       xcode-version:
-        description: 'Xcode version to use (e.g., 16.4).'
+        description: >
+          Xcode version to use (e.g., 26.0). Default tracks the macos-latest
+          image's current iOS SDK (iOS 26) — required for Compose Multiplatform
+          targets that reference iOS 26 APIs (UIViewLayoutRegion,
+          swift_DarwinFoundation, UIUtilities). Override to an older Xcode
+          (e.g., '16.4') for projects pinned to pre-iOS-26 SDKs.
         required: false
-        default: '16.4'
+        default: '26.0'
         type: string
 
       release_type:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -59,7 +59,7 @@
 #   | `use_cocoapods` | Whether to use CocoaPods for integrating the shared module into the iOS app | Boolean | Required **if `build_ios` = true** |
 #   | `shared_module` | Gradle path to the shared Kotlin Multiplatform module used in the iOS app (e.g., :cmp-shared, :shared) | String | Required **if `build_ios` = true** |
 #   | `java-version` | Java version to use (e.g., 17, 21) | String | No |
-#   | `xcode-version`| Xcode version to use (e.g., 16.4) | String | No       |
+#   | `xcode-version`| Xcode version to use (e.g., 26.0) | String | No       |
 #
 ### Usage Example
 #   ```yaml
@@ -113,9 +113,14 @@ on:
         default: '17'
 
       xcode-version:
-        description: 'Xcode version to use (e.g., 16.4).'
+        description: >
+          Xcode version to use (e.g., 26.0). Default tracks the macos-latest
+          image's current iOS SDK (iOS 26) — required for Compose Multiplatform
+          targets that reference iOS 26 APIs (UIViewLayoutRegion,
+          swift_DarwinFoundation, UIUtilities). Override to an older Xcode
+          (e.g., '16.4') for projects pinned to pre-iOS-26 SDKs.
         required: false
-        default: '16.4'
+        default: '26.0'
         type: string
 
       android_package_name:


### PR DESCRIPTION
## Summary

Bumps the default `xcode-version` input in both reusable workflows from `'16.4'` to `'26.0'` so consumer projects get an iOS-26-SDK-capable Xcode by default.

## Why

Compose Multiplatform's iOS targets now emit references to iOS 26 SDK classes (`UIViewLayoutRegion`, `swift_DarwinFoundation1/2/3`, `UIUtilities`) unconditionally. Consumer projects building against the workflow's default `xcode-version='16.4'` fail at the link step:

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_UIViewLayoutRegion", referenced from:
     in ComposeApp(CMPLayoutRegion.o)
ld: symbol(s) not found for architecture arm64
```

## What changes

- `.github/workflows/pr-check.yaml` — `default: '16.4'` → `default: '26.0'`
- `.github/workflows/multi-platform-build-and-publish.yaml` — same
- Description blocks expanded to document the iOS 26 SDK rationale + override path for pre-iOS-26 projects (`xcode-version: '16.4'`)
- The `(e.g., 16.4)` doc-table example in pr-check.yaml header updated to `(e.g., 26.0)`

## Runner image confirmation

GitHub `macos-latest` (currently `macos-15`) ships with Xcode 26.0.1, 26.1.1, 26.2, 26.3 pre-installed. `xcode-version: '26.0'` resolves to 26.0.1 via `maxim-lobanov/setup-xcode-action`'s prefix match — exact match guaranteed. Verified against the [macos-15 image readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md).

## Compatibility

Non-breaking for consumers that explicitly set `xcode-version`. Consumers relying on the old default `'16.4'` need to either:
1. Adopt iOS 26 SDK (recommended — matches current ecosystem)
2. Pin explicitly: `xcode-version: '16.4'`

## Motivating use-case

[openMF/kmp-project-template PR #185](https://github.com/openMF/kmp-project-template/pull/185) (AGP9 migration) hit this issue. The PR is currently passing `xcode-version: '26.0'` as an override (after v1.0.12 added the input). Once this PR merges + tags v1.0.13, that consumer can drop the override.

## Test plan

- [ ] Tag v1.0.13 after merge
- [ ] Update openMF/kmp-project-template PR #185 to use @v1.0.13 + drop the explicit `xcode-version` override
- [ ] Verify openMF/kmp-project-template PR Checks → Build iOS App passes on the next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)