### PR TITLE
fix(ci): switch build_web_app runner from windows-latest to ubuntu-latest

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -250,18 +250,17 @@ jobs:
   build_web_app:
     name: Build Web Application
     needs: [ checks ]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Create Supabase credentials file
-        shell: pwsh
         run: |
-          if ('${{ secrets.supabase_creds }}' -ne '') {
-            New-Item -ItemType Directory -Force -Path secrets
-            [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${{ secrets.supabase_creds }}')) | Out-File -FilePath secrets/supabaseCredentialsFile.json -Encoding UTF8
-          }
+          if [ -n "${{ secrets.supabase_creds }}" ]; then
+            mkdir -p secrets
+            echo '${{ secrets.supabase_creds }}' | base64 --decode > secrets/supabaseCredentialsFile.json
+          fi
 
       - name: Build Web App
         uses: openMF/mifos-x-actionhub-build-web-app-kmp@v1.0.1


### PR DESCRIPTION
## Summary
- `build_web_app` job in `pr-check.yaml` was hardcoded to `windows-latest`
- KMP/WASM web builds are platform-agnostic Gradle tasks — no Windows toolchain required
- Replaced PowerShell `supabase_creds` step with the same bash `base64 --decode` block used by android/iOS jobs

## Benefits
- Faster CI (ubuntu runners are ~2× faster than windows on GHA)
- Cheaper GHA minutes
- Local dry-run via `nektos/act` works without `--P windows-latest=...` platform override

## Test plan
- [ ] Dry-run via `act pull_request -j build_web_app --dryrun` resolves without platform skip warning
- [ ] GHA run on PR passes `Build Web Application` job on ubuntu runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)