### PR TITLE
feat(workflows): add 4 release-ladder reusable workflows (ADDITIVE)

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -1,0 +1,136 @@
+# .github/workflows/release-android.yaml
+#
+# ADDITIVE — reusable workflow for the Android promotion ladder.
+# Companion to existing android-build-and-publish.yaml + promote-to-production.yaml.
+# Existing workflows are UNCHANGED — community consumers using @v1.0.16 are unaffected.
+#
+# Promotion model:
+#   Stage 0 (firebase)    — out-of-band dev/QA, no approval gate
+#   Stage 1 (internal)    — Play Internal track, 1 reviewer required
+#   Stage 2 (beta)        — Play Open Beta, 1 reviewer required (promote, no rebuild)
+#   Stage 3 (production)  — Play Production, 2 reviewers + wait timer (promote, no rebuild)
+#
+# Approval gates: GHA `environment:` protection rules (configured per-consumer-repo).
+#   environment: android-firebase            → no protection
+#   environment: android-play-internal       → 1 reviewer
+#   environment: android-play-beta           → 1 reviewer
+#   environment: android-play-production     → 2 reviewers + 30min wait timer
+#
+# Supersede semantics: concurrency.group=release-android + cancel-in-progress=true.
+# A NEW release run cancels any pending approvals on the previous run.
+#
+# Resume support: `starting_rung` input skips earlier stages (e.g. retry after
+# rung 3 failed but earlier rungs were fine).
+#
+# Composite refs use therajanmaurya/* during initial dev phase. Will rebind to
+# openMF/* at v2.0.0 tag (post-transfer).
+name: Release · Android (ladder)
+
+on:
+  workflow_call:
+    inputs:
+      android_package_name:
+        description: 'Android Gradle module (e.g. cmp-android)'
+        required: true
+        type: string
+      version_tag:
+        description: 'Version tag (e.g. v2026.06.15)'
+        required: true
+        type: string
+      starting_rung:
+        description: "Resume from a specific rung: firebase | internal | beta | production"
+        required: false
+        type: string
+        default: 'firebase'
+      tester_groups:
+        description: 'Firebase tester groups (comma-separated, Stage 0 only)'
+        required: false
+        type: string
+        default: 'qa-team,beta-testers'
+      production_rollout:
+        description: 'Stage 3 staged rollout percentage (0.0-1.0)'
+        required: false
+        type: string
+        default: '0.10'
+
+    secrets:
+      google_services:           { required: true }
+      firebase_creds:            { required: true }
+      playstore_creds:           { required: true }
+      release_keystore:          { required: true }
+      keystore_password:         { required: true }
+      keystore_alias:            { required: true }
+      keystore_alias_password:   { required: true }
+
+concurrency:
+  group: release-android
+  cancel-in-progress: true
+
+jobs:
+  stage-0-firebase:
+    name: Stage 0 — Firebase App Distribution
+    if: contains(fromJSON('["firebase","internal","beta","production"]'), inputs.starting_rung)
+    runs-on: ubuntu-latest
+    environment: android-firebase
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish to Firebase
+        uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/firebase-distribution@main
+        with:
+          android_package_name:     ${{ inputs.android_package_name }}
+          release_type:             prod
+          google_services:          ${{ secrets.google_services }}
+          firebase_creds:           ${{ secrets.firebase_creds }}
+          keystore_file:            ${{ secrets.release_keystore }}
+          keystore_password:        ${{ secrets.keystore_password }}
+          keystore_alias:           ${{ secrets.keystore_alias }}
+          keystore_alias_password:  ${{ secrets.keystore_alias_password }}
+          tester_groups:            ${{ inputs.tester_groups }}
+
+  stage-1-play-internal:
+    name: Stage 1 — Play Internal (approval required)
+    needs: [stage-0-firebase]
+    if: contains(fromJSON('["internal","beta","production"]'), inputs.starting_rung) && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    environment: android-play-internal
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload to Play Internal
+        uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/play-store-internal@main
+        with:
+          android_package_name:     ${{ inputs.android_package_name }}
+          google_services:          ${{ secrets.google_services }}
+          playstore_creds:          ${{ secrets.playstore_creds }}
+          keystore_file:            ${{ secrets.release_keystore }}
+          keystore_password:        ${{ secrets.keystore_password }}
+          keystore_alias:           ${{ secrets.keystore_alias }}
+          keystore_alias_password:  ${{ secrets.keystore_alias_password }}
+
+  stage-2-promote-to-beta:
+    name: Stage 2 — Promote to Open Beta (approval required, no rebuild)
+    needs: [stage-1-play-internal]
+    if: contains(fromJSON('["beta","production"]'), inputs.starting_rung) && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    environment: android-play-beta
+    steps:
+      - uses: actions/checkout@v4
+      - name: Promote Internal → Beta
+        uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/promote-to-beta@main
+        with:
+          android_package_name: ${{ inputs.android_package_name }}
+          playstore_creds:      ${{ secrets.playstore_creds }}
+
+  stage-3-promote-to-production:
+    name: Stage 3 — Promote to Production (2 reviewers + wait timer, no rebuild)
+    needs: [stage-2-promote-to-beta]
+    if: inputs.starting_rung == 'production' && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    environment: android-play-production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Promote Beta → Production (staged rollout)
+        uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/promote-to-production@main
+        with:
+          android_package_name: ${{ inputs.android_package_name }}
+          playstore_creds:      ${{ secrets.playstore_creds }}
+          rollout:              ${{ inputs.production_rollout }}

--- a/.github/workflows/release-apple.yaml
+++ b/.github/workflows/release-apple.yaml
@@ -1,0 +1,150 @@
+# .github/workflows/release-apple.yaml
+#
+# ADDITIVE — reusable workflow for Apple platforms (iOS or macOS) promotion ladder.
+# Companion to existing iOS/macOS workflows. Existing workflows UNCHANGED.
+#
+# Promotion model (uniform across iOS + macOS, switched by `platform` input):
+#   Stage 0 (firebase)        — out-of-band dev/QA (iOS only; macOS skips)
+#   Stage 1 (internal)        — TestFlight Internal, 1 reviewer required
+#   Stage 2 (beta)            — TestFlight External (Apple beta review ~24h), 1 reviewer
+#   Stage 3 (production)      — App Store / Mac App Store (Apple review 1-3d), 2 reviewers + wait
+name: Release · Apple (ladder)
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: "Platform: ios | mac"
+        required: true
+        type: string
+      package_name:
+        description: 'Gradle module (e.g. cmp-ios or cmp-desktop)'
+        required: true
+        type: string
+      shared_module:
+        description: 'KMP shared module path (e.g. cmp-shared)'
+        required: true
+        type: string
+      version_tag:
+        description: 'Version tag'
+        required: true
+        type: string
+      starting_rung:
+        description: "Resume from: firebase | internal | beta | production"
+        required: false
+        type: string
+        default: 'internal'
+
+    secrets:
+      appstore_key_id:           { required: true }
+      appstore_issuer_id:        { required: true }
+      appstore_auth_key:         { required: true }
+      match_password:            { required: true }
+      match_ssh_private_key:     { required: true }
+      firebase_creds:            { required: false }
+
+concurrency:
+  group: release-apple-${{ inputs.platform }}
+  cancel-in-progress: true
+
+jobs:
+  stage-0-firebase:
+    name: Stage 0 — Firebase App Distribution (iOS only)
+    if: |
+      inputs.platform == 'ios' &&
+      contains(fromJSON('["firebase","internal","beta","production"]'), inputs.starting_rung)
+    runs-on: macos-14
+    environment: ios-firebase
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish to Firebase
+        uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/ios-firebase-distribution@main
+        with:
+          ios_package_name:      ${{ inputs.package_name }}
+          shared_module:         ${{ inputs.shared_module }}
+          appstore_key_id:       ${{ secrets.appstore_key_id }}
+          appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
+          appstore_auth_key:     ${{ secrets.appstore_auth_key }}
+          match_password:        ${{ secrets.match_password }}
+          match_ssh_private_key: ${{ secrets.match_ssh_private_key }}
+          firebase_creds:        ${{ secrets.firebase_creds }}
+
+  stage-1-testflight-internal:
+    name: Stage 1 — TestFlight Internal
+    needs: [stage-0-firebase]
+    if: contains(fromJSON('["internal","beta","production"]'), inputs.starting_rung) && !cancelled() && !failure()
+    runs-on: macos-14
+    environment: ${{ inputs.platform }}-testflight-internal
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload to TestFlight Internal (iOS)
+        if: inputs.platform == 'ios'
+        uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/ios-testflight-internal@main
+        with:
+          ios_package_name:      ${{ inputs.package_name }}
+          shared_module:         ${{ inputs.shared_module }}
+          appstore_key_id:       ${{ secrets.appstore_key_id }}
+          appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
+          appstore_auth_key:     ${{ secrets.appstore_auth_key }}
+          match_password:        ${{ secrets.match_password }}
+          match_ssh_private_key: ${{ secrets.match_ssh_private_key }}
+      - name: Upload to Mac TestFlight Internal (macOS)
+        if: inputs.platform == 'mac'
+        uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/mac-testflight-internal@main
+        with:
+          desktop_package_name:  ${{ inputs.package_name }}
+          appstore_key_id:       ${{ secrets.appstore_key_id }}
+          appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
+          appstore_auth_key:     ${{ secrets.appstore_auth_key }}
+          match_password:        ${{ secrets.match_password }}
+          match_ssh_private_key: ${{ secrets.match_ssh_private_key }}
+
+  stage-2-promote-to-external-beta:
+    name: Stage 2 — Promote to TestFlight External (no rebuild)
+    needs: [stage-1-testflight-internal]
+    if: contains(fromJSON('["beta","production"]'), inputs.starting_rung) && !cancelled() && !failure()
+    runs-on: macos-14
+    environment: ${{ inputs.platform }}-testflight-external
+    steps:
+      - uses: actions/checkout@v4
+      - name: Promote iOS TF Internal → External
+        if: inputs.platform == 'ios'
+        uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/ios-promote-to-testflight-external@main
+        with:
+          ios_package_name:      ${{ inputs.package_name }}
+          appstore_key_id:       ${{ secrets.appstore_key_id }}
+          appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
+          appstore_auth_key:     ${{ secrets.appstore_auth_key }}
+      - name: Promote Mac TF Internal → External
+        if: inputs.platform == 'mac'
+        uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/mac-promote-to-testflight-external@main
+        with:
+          desktop_package_name:  ${{ inputs.package_name }}
+          appstore_key_id:       ${{ secrets.appstore_key_id }}
+          appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
+          appstore_auth_key:     ${{ secrets.appstore_auth_key }}
+
+  stage-3-promote-to-app-store:
+    name: Stage 3 — Promote to App Store (2 reviewers + wait timer, no rebuild)
+    needs: [stage-2-promote-to-external-beta]
+    if: inputs.starting_rung == 'production' && !cancelled() && !failure()
+    runs-on: macos-14
+    environment: ${{ inputs.platform }}-app-store
+    steps:
+      - uses: actions/checkout@v4
+      - name: Promote iOS TF → App Store
+        if: inputs.platform == 'ios'
+        uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/ios-promote-to-app-store@main
+        with:
+          ios_package_name:      ${{ inputs.package_name }}
+          appstore_key_id:       ${{ secrets.appstore_key_id }}
+          appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
+          appstore_auth_key:     ${{ secrets.appstore_auth_key }}
+      - name: Promote Mac TF → Mac App Store
+        if: inputs.platform == 'mac'
+        uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/mac-promote-to-app-store@main
+        with:
+          desktop_package_name:  ${{ inputs.package_name }}
+          appstore_key_id:       ${{ secrets.appstore_key_id }}
+          appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
+          appstore_auth_key:     ${{ secrets.appstore_auth_key }}

--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -1,0 +1,88 @@
+# .github/workflows/release-desktop.yaml
+#
+# ADDITIVE — reusable workflow for Desktop (Windows + Linux only) direct-distribution ladder.
+# macOS desktop targets live in release-apple.yaml since they share Apple Dev Program infra.
+#
+# Promotion model (GH Release flag-flip ladder):
+#   Stage 1 (prerelease)  — GH Release prerelease=true,  latest=false
+#   Stage 2 (beta)        — GH Release prerelease=false, latest=false
+#   Stage 3 (stable)      — GH Release prerelease=false, latest=true
+#
+# Stage 1 builds + uploads. Stages 2-3 promote = flip flags only (no rebuild).
+name: Release · Desktop (Win/Linux ladder)
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: "Target: windows-exe | windows-msi-signed | windows-microsoft-store | linux-deb"
+        required: true
+        type: string
+      desktop_package_name:
+        description: 'Gradle module (e.g. cmp-desktop)'
+        required: true
+        type: string
+      github_tag:
+        description: 'GH Release tag (must already exist for promote stages)'
+        required: true
+        type: string
+      starting_rung:
+        description: "Resume from: prerelease | beta | stable"
+        required: false
+        type: string
+        default: 'prerelease'
+
+    secrets:
+      azure_client_id:                       { required: false }
+      azure_tenant_id:                       { required: false }
+      azure_subscription_id:                 { required: false }
+      azure_trusted_signing_endpoint:        { required: false }
+      azure_trusted_signing_account:         { required: false }
+      azure_cert_profile_name:               { required: false }
+      microsoft_store_client_id:             { required: false }
+      microsoft_store_client_secret:         { required: false }
+
+concurrency:
+  group: release-desktop-${{ inputs.target }}
+  cancel-in-progress: true
+
+jobs:
+  stage-1-prerelease:
+    name: Stage 1 — Prerelease (build + upload + prerelease flag)
+    if: contains(fromJSON('["prerelease","beta","stable"]'), inputs.starting_rung)
+    runs-on: ${{ (inputs.target == 'linux-deb') && 'ubuntu-latest' || 'windows-latest' }}
+    environment: desktop-${{ inputs.target }}-prerelease
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build + sign + upload (per target)
+        uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/${{ inputs.target }}@main
+        with:
+          desktop_package_name: ${{ inputs.desktop_package_name }}
+          github_tag:           ${{ inputs.github_tag }}
+          stage:                prerelease
+
+  stage-2-promote-to-beta:
+    name: Stage 2 — Promote to Beta (no rebuild — flip GH Release flags)
+    needs: [stage-1-prerelease]
+    if: contains(fromJSON('["beta","stable"]'), inputs.starting_rung) && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    environment: desktop-${{ inputs.target }}-beta
+    steps:
+      - uses: actions/checkout@v4
+      - name: Flip GH Release flags to beta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ inputs.github_tag }}" --prerelease=false --latest=false
+
+  stage-3-promote-to-stable:
+    name: Stage 3 — Promote to Stable (2 reviewers + wait, no rebuild)
+    needs: [stage-2-promote-to-beta]
+    if: inputs.starting_rung == 'stable' && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    environment: desktop-${{ inputs.target }}-stable
+    steps:
+      - uses: actions/checkout@v4
+      - name: Flip GH Release flags to stable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ inputs.github_tag }}" --prerelease=false --latest=true

--- a/.github/workflows/release-web.yaml
+++ b/.github/workflows/release-web.yaml
@@ -1,0 +1,82 @@
+# .github/workflows/release-web.yaml
+#
+# ADDITIVE — reusable workflow for Web direct-deploy ladder.
+# Companion to existing build-and-deploy-site.yaml. Existing UNCHANGED.
+#
+# Promotion model (per host, branch-based for gh-pages):
+#   Stage 1 (preview)     — gh-pages-preview branch
+#   Stage 2 (staging)     — gh-pages-staging branch (promote = copy preview → staging)
+#   Stage 3 (production)  — gh-pages branch (promote = copy staging → gh-pages)
+name: Release · Web (ladder)
+
+on:
+  workflow_call:
+    inputs:
+      host:
+        description: "Host: gh-pages | cloudflare-pages | netlify | vercel"
+        required: true
+        type: string
+        default: 'gh-pages'
+      web_package_name:
+        description: 'Gradle module (e.g. cmp-web)'
+        required: true
+        type: string
+      starting_rung:
+        description: "Resume from: preview | staging | production"
+        required: false
+        type: string
+        default: 'preview'
+
+    secrets:
+      cloudflare_api_token: { required: false }
+      netlify_auth_token:   { required: false }
+      vercel_token:         { required: false }
+
+concurrency:
+  group: release-web-${{ inputs.host }}
+  cancel-in-progress: true
+
+jobs:
+  stage-1-preview:
+    name: Stage 1 — Preview
+    if: contains(fromJSON('["preview","staging","production"]'), inputs.starting_rung)
+    runs-on: ubuntu-latest
+    environment: web-${{ inputs.host }}-preview
+    permissions: { contents: write, pages: write, id-token: write }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to preview environment
+        uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/${{ inputs.host }}@main
+        with:
+          web_package_name: ${{ inputs.web_package_name }}
+          target_stage:     preview
+
+  stage-2-staging:
+    name: Stage 2 — Staging
+    needs: [stage-1-preview]
+    if: contains(fromJSON('["staging","production"]'), inputs.starting_rung) && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    environment: web-${{ inputs.host }}-staging
+    permissions: { contents: write, pages: write, id-token: write }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to staging environment
+        uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/${{ inputs.host }}@main
+        with:
+          web_package_name: ${{ inputs.web_package_name }}
+          target_stage:     staging
+
+  stage-3-production:
+    name: Stage 3 — Production (2 reviewers + wait timer)
+    needs: [stage-2-staging]
+    if: inputs.starting_rung == 'production' && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    environment: web-${{ inputs.host }}-production
+    permissions: { contents: write, pages: write, id-token: write }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to production environment
+        uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/${{ inputs.host }}@main
+        with:
+          web_package_name: ${{ inputs.web_package_name }}
+          target_stage:     production


### PR DESCRIPTION
## Summary

Adds **4 new reusable workflows** to `.github/workflows/` implementing the promotion-ladder model with approval gates and supersede semantics:

- `release-android.yaml` — Stage 0 firebase → Stage 1 play-internal → Stage 2 promote-to-beta → Stage 3 promote-to-production
- `release-apple.yaml` — Platform input (`ios`|`mac`); same 4 stages for both, switched at composite-action layer
- `release-desktop.yaml` — Target input (`windows-exe`|`msi-signed`|`microsoft-store`|`linux-deb`); prerelease → beta → stable GH Release flag flip
- `release-web.yaml` — Host input (`gh-pages`|`cloudflare-pages`|`netlify`|`vercel`); preview → staging → production

## ⚠️ Strictly additive — zero breaking changes

Every existing workflow stays byte-for-byte unchanged:

- `multi-platform-build-and-publish.yaml` — UNCHANGED
- `promote-to-production.yaml` — UNCHANGED
- `android-build-and-publish.yaml` — UNCHANGED
- `build-and-deploy-site.yaml`, `pr-check.yaml`, `test-coverage.yaml`, etc. — UNCHANGED

Community consumers pinned at `@v1.0.16` are completely unaffected. The new workflows are opt-in by consumers that want the ladder semantics.

## Key features

| Feature | How it works |
|---|---|
| **Per-stage approval gates** | Each stage uses GHA `environment:` — consumer configures protection rules (required reviewers, wait timers) per environment in their repo settings |
| **Supersede semantics** | `concurrency: {group: release-{platform}, cancel-in-progress: true}` — a new release run cancels pending approvals on previous runs |
| **Resume from a rung** | `starting_rung` input — useful when rung 3 fails and rung 1+2 were fine |
| **Promote = no rebuild** | Stages 2-3 call the `promote-*` composite actions which do API-only operations (Fastlane Play promote, TF distribute, GH Release flag flip) |

## Composite action references

The new workflows reference 4 NEW consolidated composite-action repos (currently on `therajanmaurya/` during dev phase; will transfer to `openMF/` at v2.0.0):

- [`therajanmaurya/mifos-x-actionhub-publish-android-kmp`](https://github.com/therajanmaurya/mifos-x-actionhub-publish-android-kmp)
- [`therajanmaurya/mifos-x-actionhub-publish-apple-kmp`](https://github.com/therajanmaurya/mifos-x-actionhub-publish-apple-kmp) (iOS + macOS — all Apple Dev Program work)
- [`therajanmaurya/mifos-x-actionhub-publish-desktop-kmp`](https://github.com/therajanmaurya/mifos-x-actionhub-publish-desktop-kmp) (Windows + Linux only)
- [`therajanmaurya/mifos-x-actionhub-publish-web-kmp`](https://github.com/therajanmaurya/mifos-x-actionhub-publish-web-kmp)

These consolidate 17 existing per-target repos to 4 + the orchestrator (this repo). The plan is to:
1. Land this PR (additive — zero breakage)
2. Complete impl in the 4 new composite repos
3. Test end-to-end via consumer (`kmp-project-template`) 
4. Transfer the 4 composite repos to `openMF/`
5. Rebind `@therajanmaurya/...@main` refs in these workflows to `@openMF/...@v2.0.0`
6. Tag `mifos-x-actionhub@v1.0.17`
7. Deprecate (6mo banner) then archive the 17 legacy per-target repos

## Test plan

- [ ] PR check passes (YAML syntax, actionlint)
- [ ] Manually trigger `release-android.yaml` against `kmp-project-template` via workflow_call (after composite repos are ready)
- [ ] Verify approval gate halts at Stage 1
- [ ] Verify `starting_rung=beta` skips Stages 0-1
- [ ] Verify supersede — start a second run while first is paused at approval; first should cancel
- [ ] Repeat for ios/mac/desktop/web workflows

## Related

- Epic plan: `actionhub-constellation-consolidation` (in fork `therajanmaurya/claude-product-cycle` `plan-layer/active/`)
- Audit findings: 17 actionhub-* repos + 3 zombies, naming chaos, version drift — captured in plan
- Existing precedent: `openMF/mifos-x-actionhub-publish-desktop-app-kmp@v2.0.0` already uses subdir composite-action pattern (dmg-notarized, msi-signed, microsoft-store) — extends this to all 4 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)