### PR TITLE
chore(v2): upgrade publish-android-kmp to v2.0.4 (Play App Signing alignment)

### DIFF
--- a/.github/workflows/v2/release-android.yaml
+++ b/.github/workflows/v2/release-android.yaml
@@ -1,8 +1,12 @@
 # .github/workflows/v2/release-android.yaml
 #
-# Thin wrapper → therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.0
+# Thin wrapper → therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.4
 # Provides a stable @v1.0.17+ entry point for consumers who want the discoverable
 # mifos-x-actionhub interface instead of referencing the platform repo directly.
+#
+# Play App Signing model (per https://support.google.com/googleplay/android-developer/answer/9842756):
+# Google holds the app signing key in KMS; developer only holds the upload key.
+# Single keystore (upload_keystore) replaces the legacy release_keystore (as of v2.0.4).
 name: v2 · Release Android
 
 on:
@@ -17,7 +21,7 @@ on:
       google_services:          { required: true }
       firebase_creds:           { required: true }
       playstore_creds:          { required: true }
-      release_keystore:         { required: true }
+      upload_keystore:          { required: true }
       keystore_password:        { required: true }
       keystore_alias:           { required: true }
       keystore_alias_password:  { required: true }
@@ -30,7 +34,7 @@ on:
 
 jobs:
   delegate:
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.0
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.4
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ inputs.version_tag }}

--- a/.github/workflows/v2/release-multi-platform.yaml
+++ b/.github/workflows/v2/release-multi-platform.yaml
@@ -42,7 +42,7 @@ on:
 jobs:
   android:
     if: ${{ inputs.include_android }}
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.0
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.4
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ inputs.version_tag }}

--- a/README.md
+++ b/README.md
@@ -12,11 +12,30 @@
 
 </div>
 
+---
+
+## 🆕 v2 surface (since v1.0.17)
+
+[`.github/workflows/v2/`](./.github/workflows/v2/) — a redesigned, opt-in workflow surface featuring:
+
+- **Uniform 3-stage promotion ladder** across Android / iOS / macOS / Desktop / Web (internal → beta → production)
+- **Approval gates** via GHA `environment:` protection rules (consumer-configured)
+- **Supersede semantics** (`concurrency.cancel-in-progress: true`) — new release cancels pending approvals
+- **Auto-tag + auto-release** (`v2/tag-weekly-release.yaml`, `v2/tag-monthly-release.yaml`) — adopting the `mifos-pay` cron pattern
+- **NEW capabilities** absent in v1: `v2/rollback.yaml`, `v2/security-scan.yaml`, `v2/deployment-status.yaml`, `v2/release-notes-generate.yaml`
+
+**v1 is unchanged.** Pinned consumers at `@v1.0.16` continue working without migration. Opt-in to v2 by referencing `.github/workflows/v2/*@v1.0.17+`.
+
+📖 See [`.github/workflows/v2/README.md`](./.github/workflows/v2/README.md) for the full v2 file index, migration table, and consumer usage examples.
+
+---
+
 <details>
 <summary><kbd>Table of contents</kbd></summary>
 
 #### TOC
 
+- [🆕 v2 surface (since v1.0.17)](#-v2-surface-since-v1017)
 - [✨ Multi-Platform App Build and Publish Workflow](#multi-platform-app-build-and-publish-workflow)
     - [Workflow Usage Example](#workflow-usage-example)
 - [✨ Kotlin/JS Web Application GitHub Pages Deployment Workflow](#kotlinjs-web-application-github-pages-deployment-workflow)


### PR DESCRIPTION
## Summary
Bumps the consumer-facing v2 release-android workflow to `publish-android-kmp@v2.0.4`, which renames the workflow_call secret `release_keystore` → `upload_keystore` per [Google's Play App Signing terminology](https://support.google.com/googleplay/android-developer/answer/9842756).

## Changes
- `.github/workflows/v2/release-android.yaml`: `release_keystore` → `upload_keystore` secret declaration + bumped delegated workflow ref to `@v2.0.4`
- `.github/workflows/v2/release-multi-platform.yaml`: bumped Android job's delegated workflow ref to `@v2.0.4`

## Consumer migration
```diff
  secrets:
-   release_keystore:  ${{ secrets.RELEASE_KEYSTORE }}
+   upload_keystore:   ${{ secrets.UPLOAD_KEYSTORE_FILE }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)