### PR TITLE
feat(v2): centralize release-multi-platform — smart defaults + auto-version + firebase+internal parallel

### DIFF
--- a/.github/workflows/v2/release-multi-platform.yaml
+++ b/.github/workflows/v2/release-multi-platform.yaml
@@ -1,102 +1,241 @@
 # .github/workflows/v2/release-multi-platform.yaml
 #
-# Fan-out reusable workflow — fires the per-platform release ladders in parallel.
-# Each child has its own approval gates + supersede semantics (independent
-# concurrency groups per platform).
+# Centralized multi-platform release orchestrator. Consumer repos call this with
+# a single `workflow_call` + `secrets: inherit`. All defaults, version
+# auto-computation, and parallel firebase+internal logic live here so individual
+# consumer apps don't drift.
 #
-# v2 successor to .github/workflows/multi-platform-build-and-publish.yaml.
+# Default mode (consumer calls with no overrides):
+#   Android  → Firebase Distribution + Play Internal     (Stage 0 + Stage 1 in parallel)
+#   iOS      → Firebase Distribution + TestFlight        (Stage 0 + Stage 1 in parallel)
+#   macOS    → Mac TestFlight                            (Stage 1)
+#   Windows  → GH Pre-release                            (Stage 1-equivalent)
+#   Linux    → GH Pre-release                            (Stage 1-equivalent)
+#   Web      → Preview deploy                            (Stage 1)
+#   version_tag → auto-computed YYYY.M.D (with -.N suffix on collision)
+#
+# Promotion: re-dispatch with a higher rung per platform:
+#   Android: internal → beta → production
+#   iOS:     internal (TF) → beta (TF External) → production (App Store review)
+#   macOS:   internal (Mac TF) → beta → production (Mac App Store)
+#   Desktop: prerelease → beta → stable
+#   Web:     preview → staging → production
 name: v2 · Release Multi-Platform
+run-name: "🚀 Release ${{ inputs.version_tag || format('auto-{0}', github.run_number) }} · Android=${{ inputs.android_target }} · iOS=${{ inputs.ios_target }}"
 
 on:
   workflow_call:
     inputs:
-      version_tag:           { required: true,  type: string }
-      starting_rung:         { required: false, type: string, default: 'firebase', description: 'Per-platform: firebase | internal | beta | production' }
-      android_package_name:  { required: false, type: string, default: 'cmp-android' }
-      ios_package_name:      { required: false, type: string, default: 'cmp-ios' }
-      mac_package_name:      { required: false, type: string, default: 'cmp-desktop' }
-      shared_module:         { required: false, type: string, default: 'cmp-shared' }
-      desktop_target:        { required: false, type: string, default: 'windows-msi-signed' }
-      linux_target:          { required: false, type: string, default: 'linux-deb' }
-      web_host:              { required: false, type: string, default: 'gh-pages' }
-      web_package_name:      { required: false, type: string, default: 'cmp-web' }
-      include_android:       { required: false, type: boolean, default: true }
-      include_ios:           { required: false, type: boolean, default: true }
-      include_mac:           { required: false, type: boolean, default: false }
-      include_desktop_win:   { required: false, type: boolean, default: false }
-      include_desktop_linux: { required: false, type: boolean, default: false }
-      include_web:           { required: false, type: boolean, default: true }
-      production_rollout:    { required: false, type: string, default: '0.10' }
+      version_tag:          { required: false, type: string, default: '',                 description: 'Version tag (empty → auto-compute YYYY.M.D)' }
+      target_branch:        { required: false, type: string, default: 'dev',              description: 'Source branch to release from' }
+      android_package_name: { required: false, type: string, default: 'cmp-android' }
+      ios_package_name:     { required: false, type: string, default: 'cmp-ios' }
+      mac_package_name:     { required: false, type: string, default: 'cmp-desktop' }
+      shared_module:        { required: false, type: string, default: 'cmp-shared' }
+      desktop_package_name: { required: false, type: string, default: 'cmp-desktop' }
+      web_package_name:     { required: false, type: string, default: 'cmp-web' }
+      android_target:       { required: false, type: string, default: 'firebase+internal',  description: 'firebase+internal | firebase | internal | beta | production | skip' }
+      ios_target:           { required: false, type: string, default: 'firebase+testflight', description: 'firebase+testflight | firebase | internal | beta | production | skip' }
+      mac_target:           { required: false, type: string, default: 'internal',            description: 'internal | beta | production | skip' }
+      desktop_win_target:   { required: false, type: string, default: 'prerelease',          description: 'prerelease | beta | stable | skip' }
+      desktop_win_artifact: { required: false, type: string, default: 'windows-msi-signed',  description: 'windows-msi-signed | windows-exe | windows-microsoft-store' }
+      desktop_linux_target: { required: false, type: string, default: 'prerelease',          description: 'prerelease | beta | stable | skip' }
+      web_target:           { required: false, type: string, default: 'preview',             description: 'preview | staging | production | skip' }
+      web_host:             { required: false, type: string, default: 'gh-pages',            description: 'gh-pages | cloudflare-pages | netlify | vercel' }
+      production_rollout:   { required: false, type: string, default: '0.10',                description: 'Android staged rollout (0.0-1.0)' }
+    secrets:
+      google_services:          { required: false }
+      firebase_creds:           { required: false }
+      playstore_creds:          { required: false }
+      upload_keystore:          { required: false }
+      keystore_password:        { required: false }
+      keystore_alias:           { required: false }
+      keystore_alias_password:  { required: false }
+      appstore_key_id:          { required: false }
+      appstore_issuer_id:       { required: false }
+      appstore_auth_key:        { required: false }
+      match_password:           { required: false }
+      match_ssh_private_key:    { required: false }
 
   workflow_dispatch:
     inputs:
-      version_tag:           { required: true,  type: string }
-      starting_rung:         { required: false, type: choice, options: [firebase, internal, beta, production], default: firebase }
-      include_android:       { required: false, type: boolean, default: true }
-      include_ios:           { required: false, type: boolean, default: true }
-      include_mac:           { required: false, type: boolean, default: false }
-      include_desktop_win:   { required: false, type: boolean, default: false }
-      include_desktop_linux: { required: false, type: boolean, default: false }
-      include_web:           { required: false, type: boolean, default: true }
+      version_tag:          { required: false, type: string, default: '',                 description: 'Leave empty to auto-compute YYYY.M.D' }
+      android_target:       { required: false, type: choice, options: [firebase+internal, firebase, internal, beta, production, skip],     default: firebase+internal }
+      ios_target:           { required: false, type: choice, options: [firebase+testflight, firebase, internal, beta, production, skip],   default: firebase+testflight }
+      mac_target:           { required: false, type: choice, options: [internal, beta, production, skip],                                  default: internal }
+      desktop_win_target:   { required: false, type: choice, options: [prerelease, beta, stable, skip],                                    default: prerelease }
+      desktop_win_artifact: { required: false, type: choice, options: [windows-msi-signed, windows-exe, windows-microsoft-store],          default: windows-msi-signed }
+      desktop_linux_target: { required: false, type: choice, options: [prerelease, beta, stable, skip],                                    default: prerelease }
+      web_target:           { required: false, type: choice, options: [preview, staging, production, skip],                                default: preview }
+      web_host:             { required: false, type: choice, options: [gh-pages, cloudflare-pages, netlify, vercel],                       default: gh-pages }
+      production_rollout:   { required: false, type: string, default: '0.10' }
 
 jobs:
-  android:
-    if: ${{ inputs.include_android }}
+  version-resolve:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - id: compute
+        run: |
+          if [[ -n "${{ inputs.version_tag }}" ]]; then
+            VERSION="${{ inputs.version_tag }}"
+            echo "🔖 Using caller-provided version: $VERSION"
+          else
+            DATE=$(date -u +%Y.%-m.%-d)
+            VERSION="$DATE"
+            N=0
+            while git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1 \
+               || git rev-parse "refs/tags/v$VERSION" >/dev/null 2>&1; do
+              N=$((N+1))
+              VERSION="${DATE}.${N}"
+              if [[ $N -gt 50 ]]; then
+                echo "❌ Too many collisions for $DATE — bail"
+                exit 1
+              fi
+            done
+            echo "🔖 Auto-computed version: $VERSION"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  android-firebase:
+    name: Android · Firebase Distribution (Stage 0)
+    if: ${{ inputs.android_target == 'firebase+internal' || inputs.android_target == 'firebase' }}
+    needs: version-resolve
     uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.4
     with:
       android_package_name: ${{ inputs.android_package_name }}
-      version_tag:          ${{ inputs.version_tag }}
-      starting_rung:        ${{ inputs.starting_rung }}
-      production_rollout:   ${{ inputs.production_rollout }}
-    secrets: inherit
+      version_tag:          ${{ needs.version-resolve.outputs.version }}
+      starting_rung:        firebase
+      production_rollout:   '0.0'
+    secrets:
+      google_services:          ${{ secrets.google_services }}
+      firebase_creds:           ${{ secrets.firebase_creds }}
+      playstore_creds:          ${{ secrets.playstore_creds }}
+      upload_keystore:          ${{ secrets.upload_keystore }}
+      keystore_password:        ${{ secrets.keystore_password }}
+      keystore_alias:           ${{ secrets.keystore_alias }}
+      keystore_alias_password:  ${{ secrets.keystore_alias_password }}
 
-  ios:
-    if: ${{ inputs.include_ios }}
+  android-promote:
+    name: Android · Play Store (Internal / Beta / Production)
+    if: >-
+      ${{ inputs.android_target == 'firebase+internal'
+          || inputs.android_target == 'internal'
+          || inputs.android_target == 'beta'
+          || inputs.android_target == 'production' }}
+    needs: version-resolve
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.4
+    with:
+      android_package_name: ${{ inputs.android_package_name }}
+      version_tag:          ${{ needs.version-resolve.outputs.version }}
+      starting_rung:        ${{ inputs.android_target == 'firebase+internal' && 'internal' || inputs.android_target }}
+      production_rollout:   ${{ inputs.production_rollout }}
+    secrets:
+      google_services:          ${{ secrets.google_services }}
+      firebase_creds:           ${{ secrets.firebase_creds }}
+      playstore_creds:          ${{ secrets.playstore_creds }}
+      upload_keystore:          ${{ secrets.upload_keystore }}
+      keystore_password:        ${{ secrets.keystore_password }}
+      keystore_alias:           ${{ secrets.keystore_alias }}
+      keystore_alias_password:  ${{ secrets.keystore_alias_password }}
+
+  ios-firebase:
+    name: iOS · Firebase Distribution (Stage 0)
+    if: ${{ inputs.ios_target == 'firebase+testflight' || inputs.ios_target == 'firebase' }}
+    needs: version-resolve
     uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.0
     with:
       platform:      ios
       package_name:  ${{ inputs.ios_package_name }}
       shared_module: ${{ inputs.shared_module }}
-      version_tag:   ${{ inputs.version_tag }}
-      starting_rung: ${{ inputs.starting_rung }}
-    secrets: inherit
+      version_tag:   ${{ needs.version-resolve.outputs.version }}
+      starting_rung: firebase
+    secrets:
+      appstore_key_id:        ${{ secrets.appstore_key_id }}
+      appstore_issuer_id:     ${{ secrets.appstore_issuer_id }}
+      appstore_auth_key:      ${{ secrets.appstore_auth_key }}
+      match_password:         ${{ secrets.match_password }}
+      match_ssh_private_key:  ${{ secrets.match_ssh_private_key }}
+      firebase_creds:         ${{ secrets.firebase_creds }}
+
+  ios-promote:
+    name: iOS · TestFlight / Beta / App Store
+    if: >-
+      ${{ inputs.ios_target == 'firebase+testflight'
+          || inputs.ios_target == 'internal'
+          || inputs.ios_target == 'beta'
+          || inputs.ios_target == 'production' }}
+    needs: version-resolve
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.0
+    with:
+      platform:      ios
+      package_name:  ${{ inputs.ios_package_name }}
+      shared_module: ${{ inputs.shared_module }}
+      version_tag:   ${{ needs.version-resolve.outputs.version }}
+      starting_rung: ${{ inputs.ios_target == 'firebase+testflight' && 'internal' || inputs.ios_target }}
+    secrets:
+      appstore_key_id:        ${{ secrets.appstore_key_id }}
+      appstore_issuer_id:     ${{ secrets.appstore_issuer_id }}
+      appstore_auth_key:      ${{ secrets.appstore_auth_key }}
+      match_password:         ${{ secrets.match_password }}
+      match_ssh_private_key:  ${{ secrets.match_ssh_private_key }}
+      firebase_creds:         ${{ secrets.firebase_creds }}
 
   mac:
-    if: ${{ inputs.include_mac }}
+    name: macOS · Mac TF / Beta / MAS
+    if: ${{ inputs.mac_target != 'skip' }}
+    needs: version-resolve
     uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.0
     with:
       platform:      mac
       package_name:  ${{ inputs.mac_package_name }}
       shared_module: ${{ inputs.shared_module }}
-      version_tag:   ${{ inputs.version_tag }}
-      starting_rung: ${{ inputs.starting_rung }}
-    secrets: inherit
+      version_tag:   ${{ needs.version-resolve.outputs.version }}
+      starting_rung: ${{ inputs.mac_target }}
+    secrets:
+      appstore_key_id:        ${{ secrets.appstore_key_id }}
+      appstore_issuer_id:     ${{ secrets.appstore_issuer_id }}
+      appstore_auth_key:      ${{ secrets.appstore_auth_key }}
+      match_password:         ${{ secrets.match_password }}
+      match_ssh_private_key:  ${{ secrets.match_ssh_private_key }}
 
   desktop-win:
-    if: ${{ inputs.include_desktop_win }}
+    name: Desktop · Windows
+    if: ${{ inputs.desktop_win_target != 'skip' }}
+    needs: version-resolve
     uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.0
     with:
-      target:               ${{ inputs.desktop_target }}
-      desktop_package_name: ${{ inputs.mac_package_name }}   # both desktop targets use the cmp-desktop module
-      github_tag:           ${{ inputs.version_tag }}
-      starting_rung:        prerelease    # Win/Linux use direct-distro stages, not the Apple/Play model
+      target:               ${{ inputs.desktop_win_artifact }}
+      desktop_package_name: ${{ inputs.desktop_package_name }}
+      github_tag:           ${{ needs.version-resolve.outputs.version }}
+      starting_rung:        ${{ inputs.desktop_win_target }}
     secrets: inherit
 
   desktop-linux:
-    if: ${{ inputs.include_desktop_linux }}
+    name: Desktop · Linux
+    if: ${{ inputs.desktop_linux_target != 'skip' }}
+    needs: version-resolve
     uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.0
     with:
-      target:               ${{ inputs.linux_target }}
-      desktop_package_name: ${{ inputs.mac_package_name }}
-      github_tag:           ${{ inputs.version_tag }}
-      starting_rung:        prerelease
+      target:               linux-deb
+      desktop_package_name: ${{ inputs.desktop_package_name }}
+      github_tag:           ${{ needs.version-resolve.outputs.version }}
+      starting_rung:        ${{ inputs.desktop_linux_target }}
     secrets: inherit
 
   web:
-    if: ${{ inputs.include_web }}
+    name: Web · ${{ inputs.web_host }}
+    if: ${{ inputs.web_target != 'skip' }}
+    needs: version-resolve
     uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.0
     with:
       host:             ${{ inputs.web_host }}
       web_package_name: ${{ inputs.web_package_name }}
-      starting_rung:    preview   # Web uses preview/staging/production not the Apple/Play model
+      starting_rung:    ${{ inputs.web_target }}
     secrets: inherit


### PR DESCRIPTION
## Summary
Centralizes the multi-platform release orchestration so consumer apps don't drift. Mirrors the new shape on `openMF/kmp-project-template` PR #197.

## What's centralized
- Per-platform target dropdown (`firebase+internal`, `firebase+testflight`, `internal`, `beta`, `production`, etc.)
- Auto-computed `version_tag` (YYYY.M.D + .N suffix on collision)
- Parallel firebase+internal fan-out for Android
- Parallel firebase+testflight fan-out for iOS
- Smart defaults: every platform deploys to its Stage 0/1 default; promote via re-dispatch

## Consumer migration
Before (consumer has ~200 lines of orchestration):
```yaml
jobs:
  version-resolve: ...
  android-firebase: ...
  android-promote: ...
  ios-firebase: ...
  ios-promote: ...
  # ...etc
```
After (consumer is ~30 lines):
```yaml
jobs:
  release:
    uses: openMF/mifos-x-actionhub/.github/workflows/v2/release-multi-platform.yaml@v1.0.19
    with:
      version_tag:    ${{ inputs.version_tag }}
      android_target: ${{ inputs.android_target }}
      # ...
    secrets: inherit
```

## Test plan
- [x] YAML parses
- [ ] After merge + tag, kmp-project-template PR #197 will be updated to use @v1.0.19 thin wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)