### PR TITLE
fix(orchestrator): bump publish-web-kmp ref v2.0.5 → v2.0.6

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -343,7 +343,7 @@ jobs:
     name: Web · ${{ inputs.web_host }}
     if: ${{ inputs.web_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       host:             ${{ inputs.web_host }}
       web_package_name: ${{ inputs.web_package_name }}


### PR DESCRIPTION
## Summary

Bump the Web ladder reusable-workflow pin from `@v2.0.5` to `@v2.0.6` to absorb the parse-time fix in [therajanmaurya/mifos-x-actionhub-publish-web-kmp#3](https://github.com/therajanmaurya/mifos-x-actionhub-publish-web-kmp/pull/3).

## Why

`v2.0.5` had a workflow-parse-time bug — the Web ladder used `${{ inputs.host }}` inside `uses:`, which the GitHub Actions parser rejects:

```
Unrecognized named-value: 'inputs'.
Located at position 1 within expression: inputs.host
```

The error surfaced in **every consumer chain transitively** — the parser walks `release-multi-platform.yml` → this orchestrator's `release-multi-platform-v2.yaml@v1.0.22` → `publish-web-kmp/release.yaml@v2.0.5` and chokes before any input is bound. Even non-web dispatches were blocked.

## What landed in v2.0.6

3 dynamic-uses steps → 12 per-host conditional static-uses steps (4 hosts × 3 stages), gated by `if: inputs.host == '…'`. Only the matching step runs per dispatch. All other workflow logic (validate-secrets preflight, environment gates, concurrency, permissions) preserved verbatim.

See: [publish-web-kmp PR #3](https://github.com/therajanmaurya/mifos-x-actionhub-publish-web-kmp/pull/3) · [v2.0.6 tag](https://github.com/therajanmaurya/mifos-x-actionhub-publish-web-kmp/releases/tag/v2.0.6)

## Diff

```diff
-    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.6
```

## Post-merge actions

Per [CLAUDE.md](./CLAUDE.md) versioning policy:
1. **Tag `v1.0.23`** on `main` (patch bump for ref bump)
2. **Bump consumer wrappers** — `kmp-project-template/release-multi-platform.yml` `@v1.0.22` → `@v1.0.23`

## Test plan

- [ ] actionlint passes (workflow lints clean)
- [ ] Consumer `release-multi-platform.yml` test-dispatch hits `validate-secrets` instead of failing at parse
- [ ] Web dispatch routes to correct host-specific deploy