### PR TITLE
fix(orchestrator): bump publish-desktop-kmp ref v2.0.5 → v2.0.6

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -319,7 +319,7 @@ jobs:
     name: Desktop · Windows
     if: ${{ inputs.desktop_win_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       target:               ${{ inputs.desktop_win_artifact }}
       desktop_package_name: ${{ inputs.desktop_package_name }}
@@ -331,7 +331,7 @@ jobs:
     name: Desktop · Linux
     if: ${{ inputs.desktop_linux_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       target:               linux-deb
       desktop_package_name: ${{ inputs.desktop_package_name }}


### PR DESCRIPTION
## Summary

Pins the desktop ladder to publish-desktop-kmp@v2.0.6, which fixes the workflow-parse-time bug at `release.yaml` line 112 that broke the entire `release-multi-platform-v2.yaml@v1.0.23` consumer chain.

## Coordinated release

| Tier | Repo | PR | Tag |
|---|---|---|---|
| 3 | `therajanmaurya/mifos-x-actionhub-publish-desktop-kmp` | [#3](https://github.com/therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/pull/3) ✅ | **v2.0.6** ✅ |
| 2 | `openMF/mifos-x-actionhub` | this PR | v1.0.24 (post-merge) |
| 1 | `openMF/kmp-project-template` | #199 (drops inline desktop, bumps to @v1.0.24) | — |

## Diff

```diff
   desktop-win:
     name: Desktop · Windows
     if: ${{ inputs.desktop_win_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
…
   desktop-linux:
     name: Desktop · Linux
     if: ${{ inputs.desktop_linux_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
```

## 10-test local verification — all green

| # | Tier | Test | ✅ |
|---|---|---|---|
| T1 | Static | YAML parses | ✅ |
| T2 | Static | actionlint clean | ✅ |
| T3 | Static | Zero dynamic uses | ✅ |
| T4 | Pin | publish-android-kmp @ v2.0.5 | ✅ |
| T5 | Pin | publish-apple-kmp @ v2.0.5 | ✅ |
| T6 | Pin | publish-desktop-kmp @ v2.0.6 (this fix) | ✅ |
| T7 | Pin | publish-web-kmp @ v2.0.6 | ✅ |
| T8 | Pin | NO publish-desktop-kmp @v2.0.5 left | ✅ |
| T9 | Contract | workflow_call inputs schema preserved | ✅ |
| T10 | Live | All 4 remote tags verified to exist | ✅ |

## Post-merge actions

Per [CLAUDE.md](./CLAUDE.md) versioning policy:
1. **Tag `v1.0.24`** on `main` (patch bump for ref bump)
2. **Bump consumer wrappers** — `kmp-project-template/release-multi-platform.yml` `@v1.0.23` → `@v1.0.24` (already in PR #199 scope on that repo)