### PR TITLE
fix(orchestrator): bump publish-android-kmp + publish-apple-kmp refs to @v2.0.6

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -217,7 +217,7 @@ jobs:
     name: Android · Firebase Distribution (Stage 0)
     if: ${{ inputs.android_target == 'firebase+internal' || inputs.android_target == 'firebase' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ needs.version-resolve.outputs.version }}
@@ -240,7 +240,7 @@ jobs:
           || inputs.android_target == 'beta'
           || inputs.android_target == 'production' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ needs.version-resolve.outputs.version }}
@@ -259,7 +259,7 @@ jobs:
     name: iOS · Firebase Distribution (Stage 0)
     if: ${{ inputs.ios_target == 'firebase+testflight' || inputs.ios_target == 'firebase' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       platform:      ios
       package_name:  ${{ inputs.ios_package_name }}
@@ -282,7 +282,7 @@ jobs:
           || inputs.ios_target == 'beta'
           || inputs.ios_target == 'production' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       platform:      ios
       package_name:  ${{ inputs.ios_package_name }}
@@ -301,7 +301,7 @@ jobs:
     name: macOS · Mac TF / Beta / MAS
     if: ${{ inputs.mac_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.5
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       platform:      mac
       package_name:  ${{ inputs.mac_package_name }}


### PR DESCRIPTION
## Summary

Absorbs the gem-permission fix landed in two upstream PRs:

| Upstream | PR | Tag |
|---|---|---|
| therajanmaurya/mifos-x-actionhub-publish-android-kmp | [#5](https://github.com/therajanmaurya/mifos-x-actionhub-publish-android-kmp/pull/5) ✅ | **v2.0.6** ✅ |
| therajanmaurya/mifos-x-actionhub-publish-apple-kmp | [#4](https://github.com/therajanmaurya/mifos-x-actionhub-publish-apple-kmp/pull/4) ✅ | **v2.0.6** ✅ |

## What the upstream fixes do

GHA runner images post-2026-06 made the system gem dir `/var/lib/gems/3.2.0` root-owned. Bare gem-write operations now fail with `You don't have write permissions`.

| Action | Bug | Fix |
|---|---|---|
| `publish-android-kmp/firebase-distribution` | `fastlane add_plugin firebase_app_distribution --version=1.0.0` | Prefix with `bundle exec` (routes to vendor/bundle from setup-ruby's bundler-cache) |
| `publish-apple-kmp/ios-firebase-distribution` | same as Android | same fix |
| `publish-apple-kmp/ios-build` | `gem install cocoapods -N` | Prefix with `sudo` (CocoaPods runs at system scope) |

## Regression tests added across ALL 4 publish-* repos

Both upstream PRs added new Tier 9/10 regression tests:
- T43/T47: no bare `gem install` / `bundle install` / `fastlane add_plugin` / `gem update` in any action.yaml — must be prefixed with `sudo` or `bundle exec`
- T44/T48: every `ruby/setup-ruby` step has `bundler-cache: true`

These same tests were also added preventively to publish-desktop-kmp (PR #5) and publish-web-kmp (PR #5) so the bug class is locked across the entire chain.

## Diff

```diff
5 line bumps:
   uses: …/publish-android-kmp/.github/workflows/release.yaml@v2.0.5  →  @v2.0.6   (× 2)
   uses: …/publish-apple-kmp/.github/workflows/release.yaml@v2.0.5    →  @v2.0.6   (× 3)
```

## 29-test chain-contract suite — all green

- ✅ T0x-T07: orchestrator's 5 release-*-v2.yaml files parse + actionlint clean
- ✅ T1x (4): all 4 publish-* pinned tags verified on remote via `gh api`
- ✅ T2a-T2d: caller→callee input schema matches each publish-* declaration
- ✅ T3a-T3d: caller→callee secrets schema matches
- ✅ T40-T42: workflow_call interface contract
- ✅ T50-T52: job structure

## Post-merge actions

1. Tag `v1.0.25` on `main`
2. Bump consumer (kmp-project-template) pin from `@v1.0.24` → `@v1.0.25` (PR #201)