### PR TITLE
fix(orchestrator): bump publish-web-kmp to v2.0.10 (vercel secret declaration → v1.0.49)

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -465,7 +465,7 @@ jobs:
     name: Web · ${{ inputs.web_host }}
     if: ${{ inputs.web_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.9
+    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.10
     with:
       host:             ${{ inputs.web_host }}
       web_package_name: ${{ inputs.web_package_name }}


### PR DESCRIPTION
Bumps the web pin @v2.0.9 → @v2.0.10. v2.0.10 declares vercel_org_id + vercel_project_id (which this orchestrator passes) — without the declaration the multi-platform workflow failed at startup (undeclared-secret boundary). Tag v1.0.49.