### PR TITLE
fix(orchestrator): bump publish-desktop-kmp to v2.0.9 (create-release-if-missing → v1.0.50)

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -428,7 +428,7 @@ jobs:
     name: Desktop · Windows
     if: ${{ inputs.desktop_win_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.8
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.9
     with:
       target:               ${{ inputs.desktop_win_artifact }}
       desktop_package_name: ${{ inputs.desktop_package_name }}
@@ -450,7 +450,7 @@ jobs:
     name: Desktop · Linux
     if: ${{ inputs.desktop_linux_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.8
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.9
     with:
       target:               linux-deb
       desktop_package_name: ${{ inputs.desktop_package_name }}


### PR DESCRIPTION
Bumps desktop pin @v2.0.8 → @v2.0.9, which creates the GH Release on the first successful desktop deployment (was assumed-to-exist → failed on a fresh tag). Restores the create-once-then-accumulate-artifacts model. Tag v1.0.50.