### PR TITLE
fix(orchestrator): wire android-firebase to release-firebase.yaml (independent Firebase job) → v1.0.51

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -264,21 +264,20 @@ jobs:
     name: Android · Firebase Distribution (Stage 0)
     if: ${{ inputs.android_target == 'firebase+internal' || inputs.android_target == 'firebase' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.22
+    # Firebase App Distribution is the DEDICATED, INDEPENDENT workflow (release-firebase.yaml)
+    # since the 2026-06-22 firebase∥play split — the Play release.yaml no longer owns a Firebase
+    # node, so pointing this job there ran nothing for Firebase. release-firebase.yaml has no rung
+    # ladder (single Stage-0 Firebase deploy), hence no starting_rung / production_rollout. It
+    # DOES declare flavor / build_type, so those are now genuinely consumed.
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release-firebase.yaml@v2.0.22
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ needs.version-resolve.outputs.version }}
-      starting_rung:        firebase
-      production_rollout:   '0.0'
       tester_groups:        ${{ inputs.android_tester_groups }}
       mode:                 ${{ inputs.fastlane_mode }}
       fastlane_cwd:         ${{ inputs.fastlane_cwd }}
       pre_fastlane_script:  ${{ inputs.pre_fastlane_script }}
       runner_pool:          ${{ inputs.runner_pool_linux }}
-      # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-android-kmp release-firebase.yaml
-      # must declare matching `flavor` + `build_type` workflow_call inputs and thread them into the
-      # `bundle exec fastlane android <lane>` invocation. Until then these two `with:` values are silently
-      # ignored at the reusable-workflow boundary — EMPTY-flavor callers still see identical @v1.0.46 behavior.
       flavor:               ${{ inputs.flavor }}
       build_type:           ${{ inputs.build_type }}
     # EXPLICIT secret map (NOT inherit). This chain is cross-ORG at every hop
@@ -291,7 +290,6 @@ jobs:
     secrets:
       google_services:              ${{ secrets.google_services }}
       firebase_creds:               ${{ secrets.firebase_creds }}
-      playstore_creds:              ${{ secrets.playstore_creds }}
       upload_keystore:              ${{ secrets.upload_keystore }}
       keystore_password:            ${{ secrets.keystore_password }}
       keystore_alias:               ${{ secrets.keystore_alias }}


### PR DESCRIPTION
The android-firebase job pointed at the Play-only release.yaml (which no longer owns a Firebase node), so the independent Android Firebase distribution ran nothing. Repoints it at the dedicated release-firebase.yaml@v2.0.22, drops the ladder-only inputs (starting_rung/production_rollout) + playstore_creds (undeclared there → startup failure), and makes flavor/build_type genuinely consumed. iOS Firebase unaffected (apple keeps firebase as a rung). Tag v1.0.51.