### PR TITLE
fix(orchestrator): bump publish-desktop-kmp to v2.0.10 → v1.0.52

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -426,7 +426,7 @@ jobs:
     name: Desktop · Windows
     if: ${{ inputs.desktop_win_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.9
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.10
     with:
       target:               ${{ inputs.desktop_win_artifact }}
       desktop_package_name: ${{ inputs.desktop_package_name }}
@@ -448,7 +448,7 @@ jobs:
     name: Desktop · Linux
     if: ${{ inputs.desktop_linux_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.9
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.10
     with:
       target:               linux-deb
       desktop_package_name: ${{ inputs.desktop_package_name }}


### PR DESCRIPTION
v2.0.10 fixes the composite self-pin so create-release-if-missing actually runs (v2.0.9's fix was shipped but not referenced). Tag v1.0.52.