### PR TITLE
fix(orchestrator): mac job forwards fastlane_cwd + mode (fix mac lane loading) → v1.0.55

### DIFF
--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -403,6 +403,8 @@ jobs:
       shared_module: ${{ inputs.shared_module }}
       version_tag:   ${{ needs.version-resolve.outputs.version }}
       starting_rung: ${{ inputs.mac_target }}
+      fastlane_cwd:  ${{ inputs.fastlane_cwd }}
+      mode:          ${{ inputs.fastlane_mode }}
       runner_pool:   ${{ inputs.runner_pool_mac }}
       # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-apple-kmp release.yaml (mac path)
       # must declare matching `flavor` + `build_type` inputs and thread them into the fastlane mac lane.


### PR DESCRIPTION
The mac job didn't forward fastlane_cwd, so the mac fastlane ran from repo root and loaded the wrong Fastfile (no mac lanes) → 'Could not find lane mac desktop_testflight'. Forward fastlane_cwd + mode like the ios job. Tag v1.0.55.