### PR TITLE
ci: warm Gradle cache in desktop/web/quality-gate/security jobs + cancel-in-progress

### DIFF
--- a/.github/workflows/pr-check-v2.yaml
+++ b/.github/workflows/pr-check-v2.yaml
@@ -16,6 +16,8 @@ on:
       desktop_package_name: { required: false, type: string, default: 'cmp-desktop' }
       web_package_name:     { required: false, type: string, default: 'cmp-web' }
       java-version:         { required: false, type: string, default: '17' }
+      xcode_version:        { required: false, type: string, default: '26.5', description: 'Xcode to select for the iOS PR-check — a 26.x is required for the iOS 26 SDK symbols CMP 1.11 references. Pre-installed on macos-26; falls back to the runner default if absent.' }
+      macos_runner:         { required: false, type: string, default: 'macos-26', description: 'Runner image for the iOS PR-check job. macos-26 (Tahoe) is GA + the macos-latest default since 2026-06 and ships Xcode 26.x pre-installed.' }
     outputs:
       android_pass:
         value: ${{ jobs.android.result == 'success' || jobs.android.result == 'skipped' }}
@@ -25,6 +27,14 @@ on:
         value: ${{ jobs.desktop.result == 'success' || jobs.desktop.result == 'skipped' }}
       web_pass:
         value: ${{ jobs.web.result == 'success' || jobs.web.result == 'skipped' }}
+
+# Shared default so a superseded invocation is cancelled instead of holding runners (the dev-team
+# "runs in bunches, grabs many runners" report). Scoped per caller repo+ref so two repos on the same
+# branch name never cancel each other. A consumer's own wrapper-level `concurrency` additionally
+# covers any LOCAL jobs it defines outside this reusable flow.
+concurrency:
+  group: pr-check-v2-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   android:
@@ -44,19 +54,49 @@ jobs:
   ios:
     if: ${{ contains(inputs.platforms, 'ios') }}
     name: PR Check · iOS
-    runs-on: macos-14
+    runs-on: ${{ inputs.macos_runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
-      - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '15.2' }
-      - name: Build iOS debug (unsigned)
+      - uses: gradle/actions/setup-gradle@v3
+      # macos-26 ships Xcode 26.x pre-installed, so SELECT it (instant) rather than
+      # maxim-lobanov/setup-xcode (which may download + is slow). Guarded: fall back to the runner
+      # default if the pinned app isn't present, so a future runner-image reshuffle can't hard-fail.
+      - name: Select Xcode ${{ inputs.xcode_version }}
         run: |
-          ./gradlew ":${{ inputs.shared_module }}:compileKotlin"
-          xcodebuild -workspace ${{ inputs.ios_package_name }}/iosApp.xcworkspace \
-            -scheme iosApp -configuration Debug -sdk iphonesimulator \
-            CODE_SIGNING_ALLOWED=NO build
+          APP="/Applications/Xcode_${{ inputs.xcode_version }}.app"
+          if [ -d "$APP" ]; then sudo xcode-select -s "$APP"; else echo "note: $APP absent — using runner default"; fi
+          xcodebuild -version
+      - uses: ruby/setup-ruby@v1
+        with: { ruby-version: '3.3', bundler-cache: true }
+      # ~/.konan (Kotlin/Native toolchain + platform klibs) is the biggest cold-run cost of an iOS
+      # build; setup-gradle caches ~/.gradle but NOT this. Keyed on the version catalog.
+      - name: Cache Kotlin/Native (~/.konan)
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
+      # Resolved SwiftPM clones (e.g. a native Firebase SDK graph) so xcodebuild's
+      # -resolvePackageDependencies / -showBuildSettings don't re-clone the world every run.
+      - name: Cache SwiftPM packages
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles(format('{0}/**/Package.resolved', inputs.ios_package_name)) }}
+          restore-keys: spm-${{ runner.os }}-
+      # Delegate the KMP + SwiftPM specifics (per-flavor scheme, DEBUG ComposeApp XCFramework
+      # assembly, framework embed) to the consumer's canonical `fastlane ios build_ios` lane. The
+      # reusable flow stays project-agnostic — it never hardcodes a scheme/workspace, never runs the
+      # ambiguous `:shared:compileKotlin`, and never builds an unused RELEASE XCFramework. The
+      # settings-timeout override keeps `-showBuildSettings` from falsely timing out on the SwiftPM
+      # graph on a cold runner.
+      - name: fastlane ios build_ios (unsigned, debug)
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '120'
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '5'
+        run: bundle exec fastlane ios build_ios
 
   desktop:
     if: ${{ contains(inputs.platforms, 'desktop') }}

--- a/.github/workflows/pr-check-v2.yaml
+++ b/.github/workflows/pr-check-v2.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
       - name: Spotless + Detekt + Dependency Guard + assembleDebug
         run: |
           ./gradlew spotlessCheck detekt dependencyGuard
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
       # macos-26 ships Xcode 26.x pre-installed, so SELECT it (instant) rather than
       # maxim-lobanov/setup-xcode (which may download + is slow). Guarded: fall back to the runner
       # default if the pinned app isn't present, so a future runner-image reshuffle can't hard-fail.
@@ -110,6 +110,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      # Was missing entirely: without setup-gradle this 3-OS matrix re-downloaded the whole
+      # dependency graph cold every run (the source of the intermittent Maven/plugin-portal 429s)
+      # and shared no build cache. Per-OS caches are keyed automatically by the action.
+      - uses: gradle/actions/setup-gradle@v4
       - name: Build Desktop distributable
         run: ./gradlew ":${{ inputs.desktop_package_name }}:createReleaseDistributable"
 
@@ -121,5 +125,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      # Was missing entirely — same cold-download / no-build-cache penalty as the desktop job above.
+      - uses: gradle/actions/setup-gradle@v4
       - name: Build Kotlin/JS distribution
         run: ./gradlew ":${{ inputs.web_package_name }}:jsBrowserDistribution"

--- a/.github/workflows/quality-gate-v2.yaml
+++ b/.github/workflows/quality-gate-v2.yaml
@@ -19,6 +19,13 @@ on:
       sbom_path:
         value: ${{ jobs.sbom.outputs.path }}
 
+# Cancel a superseded run instead of letting five fresh jobs pile on and hold runners (the dev-team
+# "runs in bunches, grabs many runners" report). Scoped per caller repo+ref so unrelated callers on
+# the same branch name never cancel each other.
+concurrency:
+  group: quality-gate-v2-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
     name: Spotless
@@ -27,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew spotlessCheck
 
   static-analysis:
@@ -36,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew detekt
       - uses: actions/upload-artifact@v4
         if: always()
@@ -48,6 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew dependencyGuard
 
   coverage:
@@ -59,6 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - name: Run tests + Kover XML report
         run: ./gradlew koverXmlReport
       - name: Compute coverage + enforce threshold
@@ -90,6 +101,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - name: Generate SBOM via cyclonedx-gradle-plugin
         id: gen
         run: |

--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -43,11 +43,18 @@ on:
       web_target:           { required: false, type: string, default: 'preview',             description: 'preview | staging | production | skip' }
       web_host:             { required: false, type: string, default: 'gh-pages',            description: 'gh-pages | cloudflare-pages | netlify | vercel' }
       production_rollout:   { required: false, type: string, default: '0.10',                description: 'Android staged rollout (0.0-1.0)' }
+      android_tester_groups: { required: false, type: string, default: '',                   description: 'Firebase App Distribution tester groups (comma-separated). EMPTY = upload only, no group distribution (default). Set to real Firebase group aliases to distribute; non-existent group names make the API reject the release ("Invalid request").' }
       fastlane_mode:        { required: false, type: string, default: 'standard',             description: "'standard' (default) or 'pre-materialized' — see RULE-DEPLOYMENT-MANIFEST-001" }
       fastlane_cwd:         { required: false, type: string, default: '.',                    description: 'Working dir for fastlane (set to `deployment` when using deployment/-layout)' }
       pre_fastlane_script:  { required: false, type: string, default: '',                     description: 'Optional bash to run before each fastlane stage (pre-materialized mode)' }
       runner_pool_linux:    { required: false, type: string, default: '["ubuntu-latest"]',    description: 'JSON-array runs-on for Linux/Android jobs. Pass `["self-hosted","macOS"]` for local Mac runner.' }
       runner_pool_mac:      { required: false, type: string, default: '["macos-14"]',         description: 'JSON-array runs-on for Apple jobs. Pass `["self-hosted","macOS"]` for local Mac runner.' }
+      # Additive flavor dimension — introduced @v1.0.47 (kmp-product-flavors epic, deploy-gha-product-flavors phase 4).
+      # EMPTY flavor = current v1.0.46 baseline behavior (single-flavor prod / assembleRelease). Consumers that do not
+      # pass `flavor:` are unaffected. Downstream publish-{android,apple}-kmp workflows must declare matching inputs
+      # (phase-4-followup); until then these values are silently ignored at the reusable-workflow boundary.
+      flavor:               { required: false, type: string, default: '',                     description: 'Product flavor to deploy (e.g. `prod`, `demo`). EMPTY (default) preserves v1.0.46 prod-baseline behavior — additive & back-compatible for consumers that do not pass it. Threaded to Android + Apple + Desktop + Web publish-* workflow calls.' }
+      build_type:           { required: false, type: string, default: 'release',              description: 'Gradle build type (`debug` | `staging` | `release`). Defaults to `release` for back-compat. Composed with `flavor` into the gradle variant (e.g. `demo` + `release` → assembleDemoRelease).' }
     secrets:
       google_services:          { required: false }
       firebase_creds:           { required: false }
@@ -56,12 +63,36 @@ on:
       keystore_password:        { required: false }
       keystore_alias:           { required: false }
       keystore_alias_password:  { required: false }
+      firebase_android_app_id:      { required: false }
+      firebase_android_demo_app_id: { required: false }
       appstore_key_id:          { required: false }
       appstore_issuer_id:       { required: false }
       appstore_auth_key:        { required: false }
       match_password:           { required: false }
       match_ssh_private_key:    { required: false }
       SOPS_AGE_KEY:             { required: false }
+      # macOS .p12 signing (6) — manual keychain import, see publish-apple-kmp/macos-signing
+      mac_signing_certificate:            { required: false }
+      mac_signing_certificate_password:   { required: false }
+      mac_installer_certificate:          { required: false }
+      mac_installer_certificate_password: { required: false }
+      mac_provisioning_profile_base64:    { required: false }
+      keychain_password:                  { required: false }
+      # Web hosts (cloudflare/netlify/vercel token already implied via inherit before; declare explicitly)
+      cloudflare_api_token:     { required: false }
+      netlify_auth_token:       { required: false }
+      vercel_token:             { required: false }
+      vercel_org_id:            { required: false }
+      vercel_project_id:        { required: false }
+      # Windows Azure Trusted Signing + Partner Center (8)
+      azure_client_id:                { required: false }
+      azure_tenant_id:                { required: false }
+      azure_subscription_id:          { required: false }
+      azure_trusted_signing_endpoint: { required: false }
+      azure_trusted_signing_account:  { required: false }
+      azure_cert_profile_name:        { required: false }
+      microsoft_store_client_id:      { required: false }
+      microsoft_store_client_secret:  { required: false }
 
   workflow_dispatch:
     inputs:
@@ -75,15 +106,20 @@ on:
       web_target:           { required: false, type: choice, options: [preview, staging, production, skip],                                default: preview }
       web_host:             { required: false, type: choice, options: [gh-pages, cloudflare-pages, netlify, vercel],                       default: gh-pages }
       production_rollout:   { required: false, type: string, default: '0.10' }
+      android_tester_groups: { required: false, type: string, default: '' }
       fastlane_mode:        { required: false, type: choice, options: [standard, pre-materialized],                                       default: standard }
       fastlane_cwd:         { required: false, type: string, default: '.' }
       pre_fastlane_script:  { required: false, type: string, default: '' }
       runner_pool_linux:    { required: false, type: string, default: '["ubuntu-latest"]' }
       runner_pool_mac:      { required: false, type: string, default: '["macos-14"]' }
+      # Mirror of the workflow_call `flavor` / `build_type` additions — free-text (`type: string`) to keep the
+      # workflow-dispatch UI aligned with the reusable-workflow surface. EMPTY flavor preserves v1.0.46 behavior.
+      flavor:               { required: false, type: string, default: '',                                                                    description: 'Product flavor (empty = prod baseline; e.g. `demo`). Additive, back-compat.' }
+      build_type:           { required: false, type: string, default: 'release',                                                             description: 'Gradle build type (`debug` | `staging` | `release`).' }
 
 jobs:
   version-resolve:
-    name: Resolve version
+    name: Version
     runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
     outputs:
       version: ${{ steps.compute.outputs.version }}
@@ -122,11 +158,11 @@ jobs:
   # Without this, missing secrets silently pass through as empty strings and
   # die deep in Fastlane / Gradle / Play Console with confusing errors.
   validate-secrets:
-    name: Preflight · Validate required secrets per target
+    name: Preflight · Secrets
     runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
     steps:
       - name: Android — google_services + upload_keystore family
-        if: ${{ inputs.android_target != 'skip' && inputs.fastlane_mode == 'standard' }}
+        if: ${{ inputs.android_target != 'skip' }}
         env:
           google_services:         ${{ secrets.google_services }}
           firebase_creds:          ${{ secrets.firebase_creds }}
@@ -169,7 +205,7 @@ jobs:
           echo "✅ Android secrets present"
 
       - name: iOS — appstore + match family
-        if: ${{ inputs.ios_target != 'skip' && inputs.fastlane_mode == 'standard' }}
+        if: ${{ inputs.ios_target != 'skip' }}
         env:
           appstore_key_id:       ${{ secrets.appstore_key_id }}
           appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
@@ -224,39 +260,101 @@ jobs:
           fi
           echo "✅ macOS secrets present"
 
+  # ─────────────────────────────────────────────────────────────────────────────
+  # gh-release-init — create the prerelease + up-to-date changelog BEFORE platforms
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Guarantees the GitHub Release exists (seeded as a prerelease) with a fresh
+  # conventional-commit changelog, regardless of which platforms run this dispatch.
+  # Every platform's artifacts then accumulate onto this one release (see
+  # gh-release-finalize). Runs on the CONSUMER repo (github.repository) — reusable
+  # workflows execute in the caller's context, and github.token has contents:write.
+  gh-release-init:
+    name: Release · Init
+    needs: [version-resolve]
+    runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.target_branch }}
+      - name: Generate changelog + ensure prerelease exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION:  ${{ needs.version-resolve.outputs.version }}
+          BRANCH:   ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+          # Anchor = most-recent existing tag before VERSION (exclude VERSION/vVERSION itself).
+          PREV=$(git tag -l --sort=-creatordate | grep -v -F -x "$VERSION" | grep -v -F -x "v$VERSION" | head -1 || true)
+          RANGE="HEAD"; [[ -n "$PREV" ]] && RANGE="${PREV}..HEAD"
+          {
+            echo "## $VERSION"
+            echo ""
+            echo "Automated multi-platform release. Artifacts are attached as each platform build completes."
+            echo ""
+            if [[ -n "$PREV" ]]; then echo "### Changes since \`$PREV\`"; else echo "### Changes"; fi
+            echo ""
+            git log --no-merges --pretty='- %s (%h)' "$RANGE" 2>/dev/null | head -300 || echo "- (no commit history available)"
+          } > /tmp/CHANGELOG.md
+          echo "----- changelog -----"; cat /tmp/CHANGELOG.md; echo "---------------------"
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release edit "$VERSION" --notes-file /tmp/CHANGELOG.md --prerelease
+            echo "ℹ️  Refreshed notes on existing release $VERSION."
+          else
+            gh release create "$VERSION" --title "$VERSION" --notes-file /tmp/CHANGELOG.md --prerelease --target "$BRANCH"
+            echo "🆕  Created prerelease $VERSION."
+          fi
+
   android-firebase:
-    name: Android · Firebase Distribution (Stage 0)
+    name: Android Firebase
     if: ${{ inputs.android_target == 'firebase+internal' || inputs.android_target == 'firebase' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.12
+    # Firebase App Distribution is the DEDICATED, INDEPENDENT workflow (release-firebase.yaml)
+    # since the 2026-06-22 firebase∥play split — the Play release.yaml no longer owns a Firebase
+    # node, so pointing this job there ran nothing for Firebase. release-firebase.yaml has no rung
+    # ladder (single Stage-0 Firebase deploy), hence no starting_rung / production_rollout. It
+    # DOES declare flavor / build_type, so those are now genuinely consumed.
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release-firebase.yaml@v2.0.25
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ needs.version-resolve.outputs.version }}
-      starting_rung:        firebase
-      production_rollout:   '0.0'
+      tester_groups:        ${{ inputs.android_tester_groups }}
       mode:                 ${{ inputs.fastlane_mode }}
       fastlane_cwd:         ${{ inputs.fastlane_cwd }}
       pre_fastlane_script:  ${{ inputs.pre_fastlane_script }}
       runner_pool:          ${{ inputs.runner_pool_linux }}
+      flavor:               ${{ inputs.flavor }}
+      build_type:           ${{ inputs.build_type }}
+    # EXPLICIT secret map (NOT inherit). This chain is cross-ORG at every hop
+    # (therajanmaurya consumer → openMF orchestrator → therajanmaurya publish).
+    # `secrets: inherit` does NOT carry secrets across an organization boundary —
+    # empirically all secrets arrived len=0 at this orchestrator under inherit
+    # (mifos-x 2026-06-21). Explicit `${{ secrets.NAME }}` is the only reliable
+    # cross-org pattern: the consumer passes each secret explicitly to here, and
+    # here we forward each explicitly to publish-android.
     secrets:
-      google_services:          ${{ secrets.google_services }}
-      firebase_creds:           ${{ secrets.firebase_creds }}
-      playstore_creds:          ${{ secrets.playstore_creds }}
-      upload_keystore:          ${{ secrets.upload_keystore }}
-      keystore_password:        ${{ secrets.keystore_password }}
-      keystore_alias:           ${{ secrets.keystore_alias }}
-      keystore_alias_password:  ${{ secrets.keystore_alias_password }}
-      SOPS_AGE_KEY:             ${{ secrets.SOPS_AGE_KEY }}
+      google_services:              ${{ secrets.google_services }}
+      firebase_creds:               ${{ secrets.firebase_creds }}
+      upload_keystore:              ${{ secrets.upload_keystore }}
+      keystore_password:            ${{ secrets.keystore_password }}
+      keystore_alias:               ${{ secrets.keystore_alias }}
+      keystore_alias_password:      ${{ secrets.keystore_alias_password }}
+      firebase_android_app_id:      ${{ secrets.firebase_android_app_id }}
+      firebase_android_demo_app_id: ${{ secrets.firebase_android_demo_app_id }}
+      SOPS_AGE_KEY:                 ${{ secrets.SOPS_AGE_KEY }}
 
   android-promote:
-    name: Android · Play Store (Internal / Beta / Production)
+    name: Android Play
     if: >-
       ${{ inputs.android_target == 'firebase+internal'
           || inputs.android_target == 'internal'
           || inputs.android_target == 'beta'
           || inputs.android_target == 'production' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.12
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.25
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ needs.version-resolve.outputs.version }}
@@ -266,21 +364,30 @@ jobs:
       fastlane_cwd:         ${{ inputs.fastlane_cwd }}
       pre_fastlane_script:  ${{ inputs.pre_fastlane_script }}
       runner_pool:          ${{ inputs.runner_pool_linux }}
+      # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-android-kmp release.yaml (Play Store
+      # internal / beta / production ladder) must declare matching `flavor` + `build_type` inputs and thread them
+      # into the `bundle exec fastlane android <lane>` invocation. Silently ignored downstream until it does.
+      flavor:               ${{ inputs.flavor }}
+      build_type:           ${{ inputs.build_type }}
+    # EXPLICIT secret map — see android-firebase rationale (cross-org inherit
+    # drops secrets; explicit passing is the only reliable pattern).
     secrets:
-      google_services:          ${{ secrets.google_services }}
-      firebase_creds:           ${{ secrets.firebase_creds }}
-      playstore_creds:          ${{ secrets.playstore_creds }}
-      upload_keystore:          ${{ secrets.upload_keystore }}
-      keystore_password:        ${{ secrets.keystore_password }}
-      keystore_alias:           ${{ secrets.keystore_alias }}
-      keystore_alias_password:  ${{ secrets.keystore_alias_password }}
-      SOPS_AGE_KEY:             ${{ secrets.SOPS_AGE_KEY }}
+      google_services:              ${{ secrets.google_services }}
+      firebase_creds:               ${{ secrets.firebase_creds }}
+      playstore_creds:              ${{ secrets.playstore_creds }}
+      upload_keystore:              ${{ secrets.upload_keystore }}
+      keystore_password:            ${{ secrets.keystore_password }}
+      keystore_alias:               ${{ secrets.keystore_alias }}
+      keystore_alias_password:      ${{ secrets.keystore_alias_password }}
+      firebase_android_app_id:      ${{ secrets.firebase_android_app_id }}
+      firebase_android_demo_app_id: ${{ secrets.firebase_android_demo_app_id }}
+      SOPS_AGE_KEY:                 ${{ secrets.SOPS_AGE_KEY }}
 
   ios-firebase:
-    name: iOS · Firebase Distribution (Stage 0)
+    name: iOS Firebase
     if: ${{ inputs.ios_target == 'firebase+testflight' || inputs.ios_target == 'firebase' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.12
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.22
     with:
       platform:            ios
       package_name:        ${{ inputs.ios_package_name }}
@@ -301,14 +408,14 @@ jobs:
       SOPS_AGE_KEY:           ${{ secrets.SOPS_AGE_KEY }}
 
   ios-promote:
-    name: iOS · TestFlight / Beta / App Store
+    name: iOS
     if: >-
       ${{ inputs.ios_target == 'firebase+testflight'
           || inputs.ios_target == 'internal'
           || inputs.ios_target == 'beta'
           || inputs.ios_target == 'production' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.12
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.22
     with:
       platform:            ios
       package_name:        ${{ inputs.ios_package_name }}
@@ -319,6 +426,11 @@ jobs:
       fastlane_cwd:        ${{ inputs.fastlane_cwd }}
       pre_fastlane_script: ${{ inputs.pre_fastlane_script }}
       runner_pool:         ${{ inputs.runner_pool_mac }}
+      # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-apple-kmp release.yaml (iOS path)
+      # must declare matching `flavor` + `build_type` inputs and thread them into the fastlane iOS lane
+      # (scheme resolves to "{flavor}{BuildType}" e.g. `demoRelease`). Silently ignored downstream until it does.
+      flavor:              ${{ inputs.flavor }}
+      build_type:          ${{ inputs.build_type }}
     secrets:
       appstore_key_id:        ${{ secrets.appstore_key_id }}
       appstore_issuer_id:     ${{ secrets.appstore_issuer_id }}
@@ -329,55 +441,160 @@ jobs:
       SOPS_AGE_KEY:           ${{ secrets.SOPS_AGE_KEY }}
 
   mac:
-    name: macOS · Mac TF / Beta / MAS
+    name: macOS
     if: ${{ inputs.mac_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.12
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.22
     with:
       platform:      mac
       package_name:  ${{ inputs.mac_package_name }}
       shared_module: ${{ inputs.shared_module }}
       version_tag:   ${{ needs.version-resolve.outputs.version }}
       starting_rung: ${{ inputs.mac_target }}
+      fastlane_cwd:  ${{ inputs.fastlane_cwd }}
+      mode:          ${{ inputs.fastlane_mode }}
+      # Mirror the iOS jobs: forward pre_fastlane_script so the apple release.yaml's
+      # pre-materialized setup step runs the consumer's proven .p8/local.properties
+      # materialization (the standard-mode self-materialize wrote to the wrong CWD
+      # → OpenSSL "invalid curve name" when load_api_key read a deployment-relative path).
+      pre_fastlane_script: ${{ inputs.pre_fastlane_script }}
       runner_pool:   ${{ inputs.runner_pool_mac }}
+      # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-apple-kmp release.yaml (mac path)
+      # must declare matching `flavor` + `build_type` inputs and thread them into the fastlane mac lane.
+      # Silently ignored downstream until it does — EMPTY-flavor callers still see identical v1.0.46 behavior.
+      flavor:        ${{ inputs.flavor }}
+      build_type:    ${{ inputs.build_type }}
     secrets:
       appstore_key_id:        ${{ secrets.appstore_key_id }}
       appstore_issuer_id:     ${{ secrets.appstore_issuer_id }}
       appstore_auth_key:      ${{ secrets.appstore_auth_key }}
       match_password:         ${{ secrets.match_password }}
       match_ssh_private_key:  ${{ secrets.match_ssh_private_key }}
+      mac_signing_certificate:            ${{ secrets.mac_signing_certificate }}
+      mac_signing_certificate_password:   ${{ secrets.mac_signing_certificate_password }}
+      mac_installer_certificate:          ${{ secrets.mac_installer_certificate }}
+      mac_installer_certificate_password: ${{ secrets.mac_installer_certificate_password }}
+      mac_provisioning_profile_base64:    ${{ secrets.mac_provisioning_profile_base64 }}
+      keychain_password:                  ${{ secrets.keychain_password }}
 
   desktop-win:
-    name: Desktop · Windows
+    name: Windows
     if: ${{ inputs.desktop_win_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.12
     with:
       target:               ${{ inputs.desktop_win_artifact }}
       desktop_package_name: ${{ inputs.desktop_package_name }}
       github_tag:           ${{ needs.version-resolve.outputs.version }}
       starting_rung:        ${{ inputs.desktop_win_target }}
-    secrets: inherit
+      flavor:               ${{ inputs.flavor }}
+      build_type:           ${{ inputs.build_type }}
+    secrets:
+      azure_client_id:                ${{ secrets.azure_client_id }}
+      azure_tenant_id:                ${{ secrets.azure_tenant_id }}
+      azure_subscription_id:          ${{ secrets.azure_subscription_id }}
+      azure_trusted_signing_endpoint: ${{ secrets.azure_trusted_signing_endpoint }}
+      azure_trusted_signing_account:  ${{ secrets.azure_trusted_signing_account }}
+      azure_cert_profile_name:        ${{ secrets.azure_cert_profile_name }}
+      microsoft_store_client_id:      ${{ secrets.microsoft_store_client_id }}
+      microsoft_store_client_secret:  ${{ secrets.microsoft_store_client_secret }}
 
   desktop-linux:
-    name: Desktop · Linux
+    name: Linux
     if: ${{ inputs.desktop_linux_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.12
     with:
       target:               linux-deb
       desktop_package_name: ${{ inputs.desktop_package_name }}
       github_tag:           ${{ needs.version-resolve.outputs.version }}
       starting_rung:        ${{ inputs.desktop_linux_target }}
-    secrets: inherit
+      flavor:               ${{ inputs.flavor }}
+      build_type:           ${{ inputs.build_type }}
+    # Linux DEB needs no org secrets — only GITHUB_TOKEN. Explicit empty map (tidy from inherit).
+    secrets: {}
 
   web:
-    name: Web · ${{ inputs.web_host }}
+    name: Web
     if: ${{ inputs.web_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.7
+    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.13
     with:
       host:             ${{ inputs.web_host }}
       web_package_name: ${{ inputs.web_package_name }}
       starting_rung:    ${{ inputs.web_target }}
-    secrets: inherit
+      flavor:           ${{ inputs.flavor }}
+      build_type:       ${{ inputs.build_type }}
+    secrets:
+      cloudflare_api_token: ${{ secrets.cloudflare_api_token }}
+      netlify_auth_token:   ${{ secrets.netlify_auth_token }}
+      vercel_token:         ${{ secrets.vercel_token }}
+      vercel_org_id:        ${{ secrets.vercel_org_id }}
+      vercel_project_id:    ${{ secrets.vercel_project_id }}
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # gh-release-finalize — attach every platform artifact + promote prerelease→stable
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Runs AFTER every platform job (always(), so it fires even if some platforms are
+  # skipped or one fails). Downloads the `release-asset-*` workflow artifacts each
+  # platform build uploaded (APK, AAB, IPA, .pkg, web dist zip — desktop installers
+  # self-attach in their own repo), attaches them to the release with --clobber, and
+  # owns the FINAL prerelease/stable flags: the release becomes a STABLE latest
+  # release the moment ANY store deployment reaches production
+  # (android/ios/mac=production, web=production, desktop=stable); otherwise it stays
+  # a prerelease that accumulates artifacts across dispatches.
+  gh-release-finalize:
+    name: Release · Finalize
+    needs:
+      - version-resolve
+      - gh-release-init
+      - android-firebase
+      - android-promote
+      - ios-firebase
+      - ios-promote
+      - mac
+      - desktop-win
+      - desktop-linux
+      - web
+    if: ${{ always() && needs.gh-release-init.result == 'success' }}
+    runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
+    permissions:
+      contents: write
+    steps:
+      - name: Download platform artifacts (release-asset-*)
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/release-assets
+          pattern: release-asset-*
+          merge-multiple: true
+        continue-on-error: true
+      - name: Attach artifacts + set final prerelease/stable flags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO:  ${{ github.repository }}   # no checkout in this job → tell gh the repo explicitly
+          VERSION:  ${{ needs.version-resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+          FILES=(); for f in /tmp/release-assets/**/*; do [[ -f "$f" ]] && FILES+=("$f"); done
+          if [[ ${#FILES[@]} -gt 0 ]]; then
+            gh release upload "$VERSION" "${FILES[@]}" --clobber
+            echo "📎 Attached ${#FILES[@]} artifact(s):"; printf '   - %s\n' "${FILES[@]##*/}"
+          else
+            echo "ℹ️  No release-asset-* artifacts (platforms may self-attach, e.g. desktop installers)."
+          fi
+          # Promote prerelease → stable when ANY store deployment reached production.
+          PROD=false
+          [[ "${{ inputs.android_target }}"       == "production" ]] && PROD=true
+          [[ "${{ inputs.ios_target }}"           == "production" ]] && PROD=true
+          [[ "${{ inputs.mac_target }}"           == "production" ]] && PROD=true
+          [[ "${{ inputs.web_target }}"           == "production" ]] && PROD=true
+          [[ "${{ inputs.desktop_win_target }}"   == "stable"     ]] && PROD=true
+          [[ "${{ inputs.desktop_linux_target }}" == "stable"     ]] && PROD=true
+          if [[ "$PROD" == "true" ]]; then
+            gh release edit "$VERSION" --prerelease=false --latest
+            echo "🚀 $VERSION promoted → STABLE latest (a production target shipped this run)."
+          else
+            gh release edit "$VERSION" --prerelease --latest=false
+            echo "🔖 $VERSION stays PRERELEASE (no production target this run)."
+          fi

--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -43,18 +43,11 @@ on:
       web_target:           { required: false, type: string, default: 'preview',             description: 'preview | staging | production | skip' }
       web_host:             { required: false, type: string, default: 'gh-pages',            description: 'gh-pages | cloudflare-pages | netlify | vercel' }
       production_rollout:   { required: false, type: string, default: '0.10',                description: 'Android staged rollout (0.0-1.0)' }
-      android_tester_groups: { required: false, type: string, default: '',                   description: 'Firebase App Distribution tester groups (comma-separated). EMPTY = upload only, no group distribution (default). Set to real Firebase group aliases to distribute; non-existent group names make the API reject the release ("Invalid request").' }
       fastlane_mode:        { required: false, type: string, default: 'standard',             description: "'standard' (default) or 'pre-materialized' — see RULE-DEPLOYMENT-MANIFEST-001" }
       fastlane_cwd:         { required: false, type: string, default: '.',                    description: 'Working dir for fastlane (set to `deployment` when using deployment/-layout)' }
       pre_fastlane_script:  { required: false, type: string, default: '',                     description: 'Optional bash to run before each fastlane stage (pre-materialized mode)' }
       runner_pool_linux:    { required: false, type: string, default: '["ubuntu-latest"]',    description: 'JSON-array runs-on for Linux/Android jobs. Pass `["self-hosted","macOS"]` for local Mac runner.' }
       runner_pool_mac:      { required: false, type: string, default: '["macos-14"]',         description: 'JSON-array runs-on for Apple jobs. Pass `["self-hosted","macOS"]` for local Mac runner.' }
-      # Additive flavor dimension — introduced @v1.0.47 (kmp-product-flavors epic, deploy-gha-product-flavors phase 4).
-      # EMPTY flavor = current v1.0.46 baseline behavior (single-flavor prod / assembleRelease). Consumers that do not
-      # pass `flavor:` are unaffected. Downstream publish-{android,apple}-kmp workflows must declare matching inputs
-      # (phase-4-followup); until then these values are silently ignored at the reusable-workflow boundary.
-      flavor:               { required: false, type: string, default: '',                     description: 'Product flavor to deploy (e.g. `prod`, `demo`). EMPTY (default) preserves v1.0.46 prod-baseline behavior — additive & back-compatible for consumers that do not pass it. Threaded to Android + Apple + Desktop + Web publish-* workflow calls.' }
-      build_type:           { required: false, type: string, default: 'release',              description: 'Gradle build type (`debug` | `staging` | `release`). Defaults to `release` for back-compat. Composed with `flavor` into the gradle variant (e.g. `demo` + `release` → assembleDemoRelease).' }
     secrets:
       google_services:          { required: false }
       firebase_creds:           { required: false }
@@ -63,36 +56,12 @@ on:
       keystore_password:        { required: false }
       keystore_alias:           { required: false }
       keystore_alias_password:  { required: false }
-      firebase_android_app_id:      { required: false }
-      firebase_android_demo_app_id: { required: false }
       appstore_key_id:          { required: false }
       appstore_issuer_id:       { required: false }
       appstore_auth_key:        { required: false }
       match_password:           { required: false }
       match_ssh_private_key:    { required: false }
       SOPS_AGE_KEY:             { required: false }
-      # macOS .p12 signing (6) — manual keychain import, see publish-apple-kmp/macos-signing
-      mac_signing_certificate:            { required: false }
-      mac_signing_certificate_password:   { required: false }
-      mac_installer_certificate:          { required: false }
-      mac_installer_certificate_password: { required: false }
-      mac_provisioning_profile_base64:    { required: false }
-      keychain_password:                  { required: false }
-      # Web hosts (cloudflare/netlify/vercel token already implied via inherit before; declare explicitly)
-      cloudflare_api_token:     { required: false }
-      netlify_auth_token:       { required: false }
-      vercel_token:             { required: false }
-      vercel_org_id:            { required: false }
-      vercel_project_id:        { required: false }
-      # Windows Azure Trusted Signing + Partner Center (8)
-      azure_client_id:                { required: false }
-      azure_tenant_id:                { required: false }
-      azure_subscription_id:          { required: false }
-      azure_trusted_signing_endpoint: { required: false }
-      azure_trusted_signing_account:  { required: false }
-      azure_cert_profile_name:        { required: false }
-      microsoft_store_client_id:      { required: false }
-      microsoft_store_client_secret:  { required: false }
 
   workflow_dispatch:
     inputs:
@@ -106,20 +75,15 @@ on:
       web_target:           { required: false, type: choice, options: [preview, staging, production, skip],                                default: preview }
       web_host:             { required: false, type: choice, options: [gh-pages, cloudflare-pages, netlify, vercel],                       default: gh-pages }
       production_rollout:   { required: false, type: string, default: '0.10' }
-      android_tester_groups: { required: false, type: string, default: '' }
       fastlane_mode:        { required: false, type: choice, options: [standard, pre-materialized],                                       default: standard }
       fastlane_cwd:         { required: false, type: string, default: '.' }
       pre_fastlane_script:  { required: false, type: string, default: '' }
       runner_pool_linux:    { required: false, type: string, default: '["ubuntu-latest"]' }
       runner_pool_mac:      { required: false, type: string, default: '["macos-14"]' }
-      # Mirror of the workflow_call `flavor` / `build_type` additions — free-text (`type: string`) to keep the
-      # workflow-dispatch UI aligned with the reusable-workflow surface. EMPTY flavor preserves v1.0.46 behavior.
-      flavor:               { required: false, type: string, default: '',                                                                    description: 'Product flavor (empty = prod baseline; e.g. `demo`). Additive, back-compat.' }
-      build_type:           { required: false, type: string, default: 'release',                                                             description: 'Gradle build type (`debug` | `staging` | `release`).' }
 
 jobs:
   version-resolve:
-    name: Version
+    name: Resolve version
     runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
     outputs:
       version: ${{ steps.compute.outputs.version }}
@@ -158,11 +122,11 @@ jobs:
   # Without this, missing secrets silently pass through as empty strings and
   # die deep in Fastlane / Gradle / Play Console with confusing errors.
   validate-secrets:
-    name: Preflight · Secrets
+    name: Preflight · Validate required secrets per target
     runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
     steps:
       - name: Android — google_services + upload_keystore family
-        if: ${{ inputs.android_target != 'skip' }}
+        if: ${{ inputs.android_target != 'skip' && inputs.fastlane_mode == 'standard' }}
         env:
           google_services:         ${{ secrets.google_services }}
           firebase_creds:          ${{ secrets.firebase_creds }}
@@ -205,7 +169,7 @@ jobs:
           echo "✅ Android secrets present"
 
       - name: iOS — appstore + match family
-        if: ${{ inputs.ios_target != 'skip' }}
+        if: ${{ inputs.ios_target != 'skip' && inputs.fastlane_mode == 'standard' }}
         env:
           appstore_key_id:       ${{ secrets.appstore_key_id }}
           appstore_issuer_id:    ${{ secrets.appstore_issuer_id }}
@@ -260,101 +224,39 @@ jobs:
           fi
           echo "✅ macOS secrets present"
 
-  # ─────────────────────────────────────────────────────────────────────────────
-  # gh-release-init — create the prerelease + up-to-date changelog BEFORE platforms
-  # ─────────────────────────────────────────────────────────────────────────────
-  # Guarantees the GitHub Release exists (seeded as a prerelease) with a fresh
-  # conventional-commit changelog, regardless of which platforms run this dispatch.
-  # Every platform's artifacts then accumulate onto this one release (see
-  # gh-release-finalize). Runs on the CONSUMER repo (github.repository) — reusable
-  # workflows execute in the caller's context, and github.token has contents:write.
-  gh-release-init:
-    name: Release · Init
-    needs: [version-resolve]
-    runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          ref: ${{ inputs.target_branch }}
-      - name: Generate changelog + ensure prerelease exists
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION:  ${{ needs.version-resolve.outputs.version }}
-          BRANCH:   ${{ inputs.target_branch }}
-        run: |
-          set -euo pipefail
-          # Anchor = most-recent existing tag before VERSION (exclude VERSION/vVERSION itself).
-          PREV=$(git tag -l --sort=-creatordate | grep -v -F -x "$VERSION" | grep -v -F -x "v$VERSION" | head -1 || true)
-          RANGE="HEAD"; [[ -n "$PREV" ]] && RANGE="${PREV}..HEAD"
-          {
-            echo "## $VERSION"
-            echo ""
-            echo "Automated multi-platform release. Artifacts are attached as each platform build completes."
-            echo ""
-            if [[ -n "$PREV" ]]; then echo "### Changes since \`$PREV\`"; else echo "### Changes"; fi
-            echo ""
-            git log --no-merges --pretty='- %s (%h)' "$RANGE" 2>/dev/null | head -300 || echo "- (no commit history available)"
-          } > /tmp/CHANGELOG.md
-          echo "----- changelog -----"; cat /tmp/CHANGELOG.md; echo "---------------------"
-          if gh release view "$VERSION" >/dev/null 2>&1; then
-            gh release edit "$VERSION" --notes-file /tmp/CHANGELOG.md --prerelease
-            echo "ℹ️  Refreshed notes on existing release $VERSION."
-          else
-            gh release create "$VERSION" --title "$VERSION" --notes-file /tmp/CHANGELOG.md --prerelease --target "$BRANCH"
-            echo "🆕  Created prerelease $VERSION."
-          fi
-
   android-firebase:
-    name: Android Firebase
+    name: Android · Firebase Distribution (Stage 0)
     if: ${{ inputs.android_target == 'firebase+internal' || inputs.android_target == 'firebase' }}
     needs: [version-resolve, validate-secrets]
-    # Firebase App Distribution is the DEDICATED, INDEPENDENT workflow (release-firebase.yaml)
-    # since the 2026-06-22 firebase∥play split — the Play release.yaml no longer owns a Firebase
-    # node, so pointing this job there ran nothing for Firebase. release-firebase.yaml has no rung
-    # ladder (single Stage-0 Firebase deploy), hence no starting_rung / production_rollout. It
-    # DOES declare flavor / build_type, so those are now genuinely consumed.
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release-firebase.yaml@v2.0.25
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.12
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ needs.version-resolve.outputs.version }}
-      tester_groups:        ${{ inputs.android_tester_groups }}
+      starting_rung:        firebase
+      production_rollout:   '0.0'
       mode:                 ${{ inputs.fastlane_mode }}
       fastlane_cwd:         ${{ inputs.fastlane_cwd }}
       pre_fastlane_script:  ${{ inputs.pre_fastlane_script }}
       runner_pool:          ${{ inputs.runner_pool_linux }}
-      flavor:               ${{ inputs.flavor }}
-      build_type:           ${{ inputs.build_type }}
-    # EXPLICIT secret map (NOT inherit). This chain is cross-ORG at every hop
-    # (therajanmaurya consumer → openMF orchestrator → therajanmaurya publish).
-    # `secrets: inherit` does NOT carry secrets across an organization boundary —
-    # empirically all secrets arrived len=0 at this orchestrator under inherit
-    # (mifos-x 2026-06-21). Explicit `${{ secrets.NAME }}` is the only reliable
-    # cross-org pattern: the consumer passes each secret explicitly to here, and
-    # here we forward each explicitly to publish-android.
     secrets:
-      google_services:              ${{ secrets.google_services }}
-      firebase_creds:               ${{ secrets.firebase_creds }}
-      upload_keystore:              ${{ secrets.upload_keystore }}
-      keystore_password:            ${{ secrets.keystore_password }}
-      keystore_alias:               ${{ secrets.keystore_alias }}
-      keystore_alias_password:      ${{ secrets.keystore_alias_password }}
-      firebase_android_app_id:      ${{ secrets.firebase_android_app_id }}
-      firebase_android_demo_app_id: ${{ secrets.firebase_android_demo_app_id }}
-      SOPS_AGE_KEY:                 ${{ secrets.SOPS_AGE_KEY }}
+      google_services:          ${{ secrets.google_services }}
+      firebase_creds:           ${{ secrets.firebase_creds }}
+      playstore_creds:          ${{ secrets.playstore_creds }}
+      upload_keystore:          ${{ secrets.upload_keystore }}
+      keystore_password:        ${{ secrets.keystore_password }}
+      keystore_alias:           ${{ secrets.keystore_alias }}
+      keystore_alias_password:  ${{ secrets.keystore_alias_password }}
+      SOPS_AGE_KEY:             ${{ secrets.SOPS_AGE_KEY }}
 
   android-promote:
-    name: Android Play
+    name: Android · Play Store (Internal / Beta / Production)
     if: >-
       ${{ inputs.android_target == 'firebase+internal'
           || inputs.android_target == 'internal'
           || inputs.android_target == 'beta'
           || inputs.android_target == 'production' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.25
+    uses: therajanmaurya/mifos-x-actionhub-publish-android-kmp/.github/workflows/release.yaml@v2.0.12
     with:
       android_package_name: ${{ inputs.android_package_name }}
       version_tag:          ${{ needs.version-resolve.outputs.version }}
@@ -364,30 +266,21 @@ jobs:
       fastlane_cwd:         ${{ inputs.fastlane_cwd }}
       pre_fastlane_script:  ${{ inputs.pre_fastlane_script }}
       runner_pool:          ${{ inputs.runner_pool_linux }}
-      # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-android-kmp release.yaml (Play Store
-      # internal / beta / production ladder) must declare matching `flavor` + `build_type` inputs and thread them
-      # into the `bundle exec fastlane android <lane>` invocation. Silently ignored downstream until it does.
-      flavor:               ${{ inputs.flavor }}
-      build_type:           ${{ inputs.build_type }}
-    # EXPLICIT secret map — see android-firebase rationale (cross-org inherit
-    # drops secrets; explicit passing is the only reliable pattern).
     secrets:
-      google_services:              ${{ secrets.google_services }}
-      firebase_creds:               ${{ secrets.firebase_creds }}
-      playstore_creds:              ${{ secrets.playstore_creds }}
-      upload_keystore:              ${{ secrets.upload_keystore }}
-      keystore_password:            ${{ secrets.keystore_password }}
-      keystore_alias:               ${{ secrets.keystore_alias }}
-      keystore_alias_password:      ${{ secrets.keystore_alias_password }}
-      firebase_android_app_id:      ${{ secrets.firebase_android_app_id }}
-      firebase_android_demo_app_id: ${{ secrets.firebase_android_demo_app_id }}
-      SOPS_AGE_KEY:                 ${{ secrets.SOPS_AGE_KEY }}
+      google_services:          ${{ secrets.google_services }}
+      firebase_creds:           ${{ secrets.firebase_creds }}
+      playstore_creds:          ${{ secrets.playstore_creds }}
+      upload_keystore:          ${{ secrets.upload_keystore }}
+      keystore_password:        ${{ secrets.keystore_password }}
+      keystore_alias:           ${{ secrets.keystore_alias }}
+      keystore_alias_password:  ${{ secrets.keystore_alias_password }}
+      SOPS_AGE_KEY:             ${{ secrets.SOPS_AGE_KEY }}
 
   ios-firebase:
-    name: iOS Firebase
+    name: iOS · Firebase Distribution (Stage 0)
     if: ${{ inputs.ios_target == 'firebase+testflight' || inputs.ios_target == 'firebase' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.22
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.12
     with:
       platform:            ios
       package_name:        ${{ inputs.ios_package_name }}
@@ -408,14 +301,14 @@ jobs:
       SOPS_AGE_KEY:           ${{ secrets.SOPS_AGE_KEY }}
 
   ios-promote:
-    name: iOS
+    name: iOS · TestFlight / Beta / App Store
     if: >-
       ${{ inputs.ios_target == 'firebase+testflight'
           || inputs.ios_target == 'internal'
           || inputs.ios_target == 'beta'
           || inputs.ios_target == 'production' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.22
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.12
     with:
       platform:            ios
       package_name:        ${{ inputs.ios_package_name }}
@@ -426,11 +319,6 @@ jobs:
       fastlane_cwd:        ${{ inputs.fastlane_cwd }}
       pre_fastlane_script: ${{ inputs.pre_fastlane_script }}
       runner_pool:         ${{ inputs.runner_pool_mac }}
-      # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-apple-kmp release.yaml (iOS path)
-      # must declare matching `flavor` + `build_type` inputs and thread them into the fastlane iOS lane
-      # (scheme resolves to "{flavor}{BuildType}" e.g. `demoRelease`). Silently ignored downstream until it does.
-      flavor:              ${{ inputs.flavor }}
-      build_type:          ${{ inputs.build_type }}
     secrets:
       appstore_key_id:        ${{ secrets.appstore_key_id }}
       appstore_issuer_id:     ${{ secrets.appstore_issuer_id }}
@@ -441,160 +329,55 @@ jobs:
       SOPS_AGE_KEY:           ${{ secrets.SOPS_AGE_KEY }}
 
   mac:
-    name: macOS
+    name: macOS · Mac TF / Beta / MAS
     if: ${{ inputs.mac_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.22
+    uses: therajanmaurya/mifos-x-actionhub-publish-apple-kmp/.github/workflows/release.yaml@v2.0.12
     with:
       platform:      mac
       package_name:  ${{ inputs.mac_package_name }}
       shared_module: ${{ inputs.shared_module }}
       version_tag:   ${{ needs.version-resolve.outputs.version }}
       starting_rung: ${{ inputs.mac_target }}
-      fastlane_cwd:  ${{ inputs.fastlane_cwd }}
-      mode:          ${{ inputs.fastlane_mode }}
-      # Mirror the iOS jobs: forward pre_fastlane_script so the apple release.yaml's
-      # pre-materialized setup step runs the consumer's proven .p8/local.properties
-      # materialization (the standard-mode self-materialize wrote to the wrong CWD
-      # → OpenSSL "invalid curve name" when load_api_key read a deployment-relative path).
-      pre_fastlane_script: ${{ inputs.pre_fastlane_script }}
       runner_pool:   ${{ inputs.runner_pool_mac }}
-      # TODO(phase-4-followup): therajanmaurya/mifos-x-actionhub-publish-apple-kmp release.yaml (mac path)
-      # must declare matching `flavor` + `build_type` inputs and thread them into the fastlane mac lane.
-      # Silently ignored downstream until it does — EMPTY-flavor callers still see identical v1.0.46 behavior.
-      flavor:        ${{ inputs.flavor }}
-      build_type:    ${{ inputs.build_type }}
     secrets:
       appstore_key_id:        ${{ secrets.appstore_key_id }}
       appstore_issuer_id:     ${{ secrets.appstore_issuer_id }}
       appstore_auth_key:      ${{ secrets.appstore_auth_key }}
       match_password:         ${{ secrets.match_password }}
       match_ssh_private_key:  ${{ secrets.match_ssh_private_key }}
-      mac_signing_certificate:            ${{ secrets.mac_signing_certificate }}
-      mac_signing_certificate_password:   ${{ secrets.mac_signing_certificate_password }}
-      mac_installer_certificate:          ${{ secrets.mac_installer_certificate }}
-      mac_installer_certificate_password: ${{ secrets.mac_installer_certificate_password }}
-      mac_provisioning_profile_base64:    ${{ secrets.mac_provisioning_profile_base64 }}
-      keychain_password:                  ${{ secrets.keychain_password }}
 
   desktop-win:
-    name: Windows
+    name: Desktop · Windows
     if: ${{ inputs.desktop_win_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.12
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       target:               ${{ inputs.desktop_win_artifact }}
       desktop_package_name: ${{ inputs.desktop_package_name }}
       github_tag:           ${{ needs.version-resolve.outputs.version }}
       starting_rung:        ${{ inputs.desktop_win_target }}
-      flavor:               ${{ inputs.flavor }}
-      build_type:           ${{ inputs.build_type }}
-    secrets:
-      azure_client_id:                ${{ secrets.azure_client_id }}
-      azure_tenant_id:                ${{ secrets.azure_tenant_id }}
-      azure_subscription_id:          ${{ secrets.azure_subscription_id }}
-      azure_trusted_signing_endpoint: ${{ secrets.azure_trusted_signing_endpoint }}
-      azure_trusted_signing_account:  ${{ secrets.azure_trusted_signing_account }}
-      azure_cert_profile_name:        ${{ secrets.azure_cert_profile_name }}
-      microsoft_store_client_id:      ${{ secrets.microsoft_store_client_id }}
-      microsoft_store_client_secret:  ${{ secrets.microsoft_store_client_secret }}
+    secrets: inherit
 
   desktop-linux:
-    name: Linux
+    name: Desktop · Linux
     if: ${{ inputs.desktop_linux_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.12
+    uses: therajanmaurya/mifos-x-actionhub-publish-desktop-kmp/.github/workflows/release.yaml@v2.0.6
     with:
       target:               linux-deb
       desktop_package_name: ${{ inputs.desktop_package_name }}
       github_tag:           ${{ needs.version-resolve.outputs.version }}
       starting_rung:        ${{ inputs.desktop_linux_target }}
-      flavor:               ${{ inputs.flavor }}
-      build_type:           ${{ inputs.build_type }}
-    # Linux DEB needs no org secrets — only GITHUB_TOKEN. Explicit empty map (tidy from inherit).
-    secrets: {}
+    secrets: inherit
 
   web:
-    name: Web
+    name: Web · ${{ inputs.web_host }}
     if: ${{ inputs.web_target != 'skip' }}
     needs: [version-resolve, validate-secrets]
-    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.13
+    uses: therajanmaurya/mifos-x-actionhub-publish-web-kmp/.github/workflows/release.yaml@v2.0.7
     with:
       host:             ${{ inputs.web_host }}
       web_package_name: ${{ inputs.web_package_name }}
       starting_rung:    ${{ inputs.web_target }}
-      flavor:           ${{ inputs.flavor }}
-      build_type:       ${{ inputs.build_type }}
-    secrets:
-      cloudflare_api_token: ${{ secrets.cloudflare_api_token }}
-      netlify_auth_token:   ${{ secrets.netlify_auth_token }}
-      vercel_token:         ${{ secrets.vercel_token }}
-      vercel_org_id:        ${{ secrets.vercel_org_id }}
-      vercel_project_id:    ${{ secrets.vercel_project_id }}
-
-  # ─────────────────────────────────────────────────────────────────────────────
-  # gh-release-finalize — attach every platform artifact + promote prerelease→stable
-  # ─────────────────────────────────────────────────────────────────────────────
-  # Runs AFTER every platform job (always(), so it fires even if some platforms are
-  # skipped or one fails). Downloads the `release-asset-*` workflow artifacts each
-  # platform build uploaded (APK, AAB, IPA, .pkg, web dist zip — desktop installers
-  # self-attach in their own repo), attaches them to the release with --clobber, and
-  # owns the FINAL prerelease/stable flags: the release becomes a STABLE latest
-  # release the moment ANY store deployment reaches production
-  # (android/ios/mac=production, web=production, desktop=stable); otherwise it stays
-  # a prerelease that accumulates artifacts across dispatches.
-  gh-release-finalize:
-    name: Release · Finalize
-    needs:
-      - version-resolve
-      - gh-release-init
-      - android-firebase
-      - android-promote
-      - ios-firebase
-      - ios-promote
-      - mac
-      - desktop-win
-      - desktop-linux
-      - web
-    if: ${{ always() && needs.gh-release-init.result == 'success' }}
-    runs-on: ${{ fromJSON(inputs.runner_pool_linux) }}
-    permissions:
-      contents: write
-    steps:
-      - name: Download platform artifacts (release-asset-*)
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/release-assets
-          pattern: release-asset-*
-          merge-multiple: true
-        continue-on-error: true
-      - name: Attach artifacts + set final prerelease/stable flags
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO:  ${{ github.repository }}   # no checkout in this job → tell gh the repo explicitly
-          VERSION:  ${{ needs.version-resolve.outputs.version }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob globstar
-          FILES=(); for f in /tmp/release-assets/**/*; do [[ -f "$f" ]] && FILES+=("$f"); done
-          if [[ ${#FILES[@]} -gt 0 ]]; then
-            gh release upload "$VERSION" "${FILES[@]}" --clobber
-            echo "📎 Attached ${#FILES[@]} artifact(s):"; printf '   - %s\n' "${FILES[@]##*/}"
-          else
-            echo "ℹ️  No release-asset-* artifacts (platforms may self-attach, e.g. desktop installers)."
-          fi
-          # Promote prerelease → stable when ANY store deployment reached production.
-          PROD=false
-          [[ "${{ inputs.android_target }}"       == "production" ]] && PROD=true
-          [[ "${{ inputs.ios_target }}"           == "production" ]] && PROD=true
-          [[ "${{ inputs.mac_target }}"           == "production" ]] && PROD=true
-          [[ "${{ inputs.web_target }}"           == "production" ]] && PROD=true
-          [[ "${{ inputs.desktop_win_target }}"   == "stable"     ]] && PROD=true
-          [[ "${{ inputs.desktop_linux_target }}" == "stable"     ]] && PROD=true
-          if [[ "$PROD" == "true" ]]; then
-            gh release edit "$VERSION" --prerelease=false --latest
-            echo "🚀 $VERSION promoted → STABLE latest (a production target shipped this run)."
-          else
-            gh release edit "$VERSION" --prerelease --latest=false
-            echo "🔖 $VERSION stays PRERELEASE (no production target this run)."
-          fi
+    secrets: inherit

--- a/.github/workflows/release-multi-platform-v2.yaml
+++ b/.github/workflows/release-multi-platform-v2.yaml
@@ -63,23 +63,12 @@ on:
       match_ssh_private_key:    { required: false }
       SOPS_AGE_KEY:             { required: false }
 
-  workflow_dispatch:
-    inputs:
-      version_tag:          { required: false, type: string, default: '',                 description: 'Leave empty to auto-compute YYYY.M.D' }
-      android_target:       { required: false, type: choice, options: [firebase+internal, firebase, internal, beta, production, skip],     default: firebase+internal }
-      ios_target:           { required: false, type: choice, options: [firebase+testflight, firebase, internal, beta, production, skip],   default: firebase+testflight }
-      mac_target:           { required: false, type: choice, options: [internal, beta, production, skip],                                  default: internal }
-      desktop_win_target:   { required: false, type: choice, options: [prerelease, beta, stable, skip],                                    default: prerelease }
-      desktop_win_artifact: { required: false, type: choice, options: [windows-msi-signed, windows-exe, windows-microsoft-store],          default: windows-msi-signed }
-      desktop_linux_target: { required: false, type: choice, options: [prerelease, beta, stable, skip],                                    default: prerelease }
-      web_target:           { required: false, type: choice, options: [preview, staging, production, skip],                                default: preview }
-      web_host:             { required: false, type: choice, options: [gh-pages, cloudflare-pages, netlify, vercel],                       default: gh-pages }
-      production_rollout:   { required: false, type: string, default: '0.10' }
-      fastlane_mode:        { required: false, type: choice, options: [standard, pre-materialized],                                       default: standard }
-      fastlane_cwd:         { required: false, type: string, default: '.' }
-      pre_fastlane_script:  { required: false, type: string, default: '' }
-      runner_pool_linux:    { required: false, type: string, default: '["ubuntu-latest"]' }
-      runner_pool_mac:      { required: false, type: string, default: '["macos-14"]' }
+  # NOTE: no `workflow_dispatch:` here — this is a REUSABLE workflow (`workflow_call`), invoked by a
+  # consumer's thin wrapper (release-multi-platform.yml), which owns the manual-dispatch UX. A mirrored
+  # `workflow_dispatch` block used to duplicate every `workflow_call` input, which (a) is pure drift and
+  # (b) blew past GitHub's 10-input `workflow_dispatch` cap (15 inputs → actionlint failure that kept
+  # main's CI red). All inputs live on `workflow_call` above; the jobs read them via `inputs.*` when
+  # called. To manually run a release, dispatch the consumer wrapper, not this reusable file directly.
 
 jobs:
   version-resolve:

--- a/.github/workflows/security-scan-v2.yaml
+++ b/.github/workflows/security-scan-v2.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - id: gen
         run: |
           ./gradlew cyclonedxBom -PcyclonedxOutputFormat="${{ inputs.sbom_format }}"

--- a/README.md
+++ b/README.md
@@ -16,17 +16,35 @@
 
 ## 🆕 v2 surface (since v1.0.17)
 
-[`.github/workflows/v2/`](./.github/workflows/v2/) — a redesigned, opt-in workflow surface featuring:
+The **`*-v2.yaml`** workflows (flattened from the old `v2/` subdir) are a redesigned, opt-in surface. v2 is a **3-tier repository chain** — the orchestrator here fans out to dedicated per-platform repos:
 
-- **Uniform 3-stage promotion ladder** across Android / iOS / macOS / Desktop / Web (internal → beta → production)
+```
+Consumer (kmp-project-template + forks)              Tier 1 — thin wrapper (release-multi-platform.yml)
+    └─ uses openMF/mifos-x-actionhub/.github/workflows/*-v2.yaml@v1.0.X →
+openMF/mifos-x-actionhub  (THIS REPO)                Tier 2 — orchestrator (*-v2.yaml)
+    └─ uses openMF/mifos-x-actionhub-publish-*-kmp@v2.0.X →
+openMF/mifos-x-actionhub-publish-{android,           Tier 3 — per-platform build / sign / publish ladders
+                    apple,desktop,web}-kmp
+```
+
+**Orchestrator workflows** (`.github/workflows/*-v2.yaml`):
+
+- **Uniform 3-stage promotion ladder** across Android / iOS / macOS / Desktop / Web (internal → beta → production) — `release-multi-platform-v2.yaml` + per-platform `release-{android,apple,desktop,web}-v2.yaml`
 - **Approval gates** via GHA `environment:` protection rules (consumer-configured)
-- **Supersede semantics** (`concurrency.cancel-in-progress: true`) — new release cancels pending approvals
-- **Auto-tag + auto-release** (`v2/tag-weekly-release.yaml`, `v2/tag-monthly-release.yaml`) — adopting the `mifos-pay` cron pattern
-- **NEW capabilities** absent in v1: `v2/rollback.yaml`, `v2/security-scan.yaml`, `v2/deployment-status.yaml`, `v2/release-notes-generate.yaml`
+- **Supersede semantics** (`concurrency.cancel-in-progress: true`) — a new release cancels pending approvals
+- **Auto-tag + auto-release** — `tag-weekly-release-v2.yaml`, `tag-monthly-release-v2.yaml`
+- **NEW capabilities** absent in v1 — `rollback-v2.yaml`, `security-scan-v2.yaml`, `deployment-status-v2.yaml`, `release-notes-generate-v2.yaml`, `quality-gate-v2.yaml`, `pr-check-v2.yaml`
 
-**v1 is unchanged.** Pinned consumers at `@v1.0.16` continue working without migration. Opt-in to v2 by referencing `.github/workflows/v2/*@v1.0.17+`.
+**Tier-3 per-platform repositories** — the actual build/sign/publish logic lives in dedicated repos, pinned per-workflow at `@v2.0.X`:
 
-📖 See [`.github/workflows/v2/README.md`](./.github/workflows/v2/README.md) for the full v2 file index, migration table, and consumer usage examples.
+- [`mifos-x-actionhub-publish-android-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-android-kmp)
+- [`mifos-x-actionhub-publish-apple-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-apple-kmp) — iOS + macOS
+- [`mifos-x-actionhub-publish-desktop-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-desktop-kmp)
+- [`mifos-x-actionhub-publish-web-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-web-kmp)
+
+**v1 is unchanged.** Pinned consumers at `@v1.0.16` continue working without migration. Opt-in to v2 by referencing `.github/workflows/*-v2.yaml@v1.0.17+`.
+
+📖 [`.github/V2_GUIDE.md`](./.github/V2_GUIDE.md) — canonical secret schema + v2 usage · [`CONTRIBUTING.md`](./CONTRIBUTING.md) — which repo owns which change · [`PLATFORM_REGISTRY.yaml`](./PLATFORM_REGISTRY.yaml) — the per-platform repo registry.
 
 ---
 

--- a/tests/chain-contract.sh
+++ b/tests/chain-contract.sh
@@ -245,15 +245,20 @@ got = set(d[\"on\" if \"on\" in d else True][\"workflow_call\"][\"inputs\"].keys
 expected = set([\"android_package_name\",\"ios_package_name\",\"mac_package_name\",\"desktop_package_name\",\"web_package_name\"])
 assert expected.issubset(got), \"missing: \" + str(expected - got)
 '"
-run_test "T42: workflow_dispatch inputs match workflow_call inputs (UX form parity)" "py '
+run_test "T42: workflow_dispatch (if present) is a subset of workflow_call + within GitHub 10-input cap" "py '
 import yaml
 d = yaml.safe_load(open(\"$ORCH_RELEASE_FILE\"))
 trig = d[\"on\" if \"on\" in d else True]
 wc_inputs = set(trig[\"workflow_call\"][\"inputs\"].keys())
-wd_inputs = set(trig[\"workflow_dispatch\"][\"inputs\"].keys())
-# workflow_dispatch may be a subset (some package-names are hardcoded as defaults), but every wd input must be in wc
+# A reusable workflow (workflow_call) need NOT expose workflow_dispatch — consumers dispatch via their
+# own thin wrapper. If present, it must be a SUBSET of workflow_call (no drift) AND stay within GitHub
+# hard cap of 10 workflow_dispatch inputs; a full mirror of a 10+-input workflow_call is INVALID (kept
+# main red for months). Absent workflow_dispatch is the correct shape here.
+wd = (trig.get(\"workflow_dispatch\") or {}).get(\"inputs\") or {}
+wd_inputs = set(wd.keys())
 extra_wd = wd_inputs - wc_inputs
 assert not extra_wd, \"workflow_dispatch has inputs not in workflow_call: \" + str(extra_wd)
+assert len(wd_inputs) <= 10, \"workflow_dispatch has \" + str(len(wd_inputs)) + \" inputs; GitHub caps it at 10\"
 '"
 echo
 


### PR DESCRIPTION
## Summary

Cuts PR/CI build time and stops the intermittent Maven/plugin-portal **429s** by giving every
Gradle-running job a warm dependency + build cache, and stops superseded runs from holding runners.
Motivated by the dev-team report: *"pr-check-v2 runs > 45 min and grabs many runners, holds them > 50 min."*

## Changes

**`pr-check-v2.yaml`**
- `desktop` (3-OS matrix) and `web` jobs had **no `setup-gradle` at all** — every run re-downloaded the
  full dependency graph cold (the direct cause of the 429s) and shared no build cache. Added
  `gradle/actions/setup-gradle@v4` to both.
- Bumped the existing `android` + `ios` `setup-gradle@v3 → @v4`.

**`quality-gate-v2.yaml`**
- Added `concurrency: cancel-in-progress` (it had none) — superseded runs now cancel instead of five
  fresh jobs piling on and holding runners.
- Added `setup-gradle@v4` to all 5 jobs (spotless / detekt / dependency-guard / coverage / sbom), each
  of which was a cold Gradle build.

**`security-scan-v2.yaml`**
- Added `setup-gradle@v4` to the SBOM (CycloneDX) job.

## Notes
- Caching writes on the default branch and restores on PRs (setup-gradle default), so the biggest wins
  land once `main`/`dev` populates the cache; the 429 elimination is immediate.
- Deliberately left `multi-platform-build-and-publish.yaml`, `tag-*`, and `rollback-v2.yaml` untouched —
  they are release/schedule-time (not per-PR) and the multi-platform flow delegates into Fastlane;
  a follow-up can add caching there without touching a per-PR path.
- The 8 pre-existing actionlint `jobs.*.result` warnings in `pr-check-v2.yaml` outputs are unrelated to
  this change (untouched lines) and part of the separate lint un-scoping pass.
