### PR TITLE
ci: iOS-job modernization + Gradle caching + cancel-in-progress (onto dev)

### DIFF
--- a/.github/workflows/pr-check-v2.yaml
+++ b/.github/workflows/pr-check-v2.yaml
@@ -16,6 +16,8 @@ on:
       desktop_package_name: { required: false, type: string, default: 'cmp-desktop' }
       web_package_name:     { required: false, type: string, default: 'cmp-web' }
       java-version:         { required: false, type: string, default: '17' }
+      xcode_version:        { required: false, type: string, default: '26.5', description: 'Xcode to select for the iOS PR-check — a 26.x is required for the iOS 26 SDK symbols CMP 1.11 references. Pre-installed on macos-26; falls back to the runner default if absent.' }
+      macos_runner:         { required: false, type: string, default: 'macos-26', description: 'Runner image for the iOS PR-check job. macos-26 (Tahoe) is GA + the macos-latest default since 2026-06 and ships Xcode 26.x pre-installed.' }
     outputs:
       android_pass:
         value: ${{ jobs.android.result == 'success' || jobs.android.result == 'skipped' }}
@@ -26,6 +28,14 @@ on:
       web_pass:
         value: ${{ jobs.web.result == 'success' || jobs.web.result == 'skipped' }}
 
+# Shared default so a superseded invocation is cancelled instead of holding runners (the dev-team
+# "runs in bunches, grabs many runners" report). Scoped per caller repo+ref so two repos on the same
+# branch name never cancel each other. A consumer's own wrapper-level `concurrency` additionally
+# covers any LOCAL jobs it defines outside this reusable flow.
+concurrency:
+  group: pr-check-v2-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   android:
     if: ${{ contains(inputs.platforms, 'android') }}
@@ -35,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
       - name: Spotless + Detekt + Dependency Guard + assembleDebug
         run: |
           ./gradlew spotlessCheck detekt dependencyGuard
@@ -44,19 +54,49 @@ jobs:
   ios:
     if: ${{ contains(inputs.platforms, 'ios') }}
     name: PR Check · iOS
-    runs-on: macos-14
+    runs-on: ${{ inputs.macos_runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
-      - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '15.2' }
-      - name: Build iOS debug (unsigned)
+      - uses: gradle/actions/setup-gradle@v4
+      # macos-26 ships Xcode 26.x pre-installed, so SELECT it (instant) rather than
+      # maxim-lobanov/setup-xcode (which may download + is slow). Guarded: fall back to the runner
+      # default if the pinned app isn't present, so a future runner-image reshuffle can't hard-fail.
+      - name: Select Xcode ${{ inputs.xcode_version }}
         run: |
-          ./gradlew ":${{ inputs.shared_module }}:compileKotlin"
-          xcodebuild -workspace ${{ inputs.ios_package_name }}/iosApp.xcworkspace \
-            -scheme iosApp -configuration Debug -sdk iphonesimulator \
-            CODE_SIGNING_ALLOWED=NO build
+          APP="/Applications/Xcode_${{ inputs.xcode_version }}.app"
+          if [ -d "$APP" ]; then sudo xcode-select -s "$APP"; else echo "note: $APP absent — using runner default"; fi
+          xcodebuild -version
+      - uses: ruby/setup-ruby@v1
+        with: { ruby-version: '3.3', bundler-cache: true }
+      # ~/.konan (Kotlin/Native toolchain + platform klibs) is the biggest cold-run cost of an iOS
+      # build; setup-gradle caches ~/.gradle but NOT this. Keyed on the version catalog.
+      - name: Cache Kotlin/Native (~/.konan)
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
+      # Resolved SwiftPM clones (e.g. a native Firebase SDK graph) so xcodebuild's
+      # -resolvePackageDependencies / -showBuildSettings don't re-clone the world every run.
+      - name: Cache SwiftPM packages
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles(format('{0}/**/Package.resolved', inputs.ios_package_name)) }}
+          restore-keys: spm-${{ runner.os }}-
+      # Delegate the KMP + SwiftPM specifics (per-flavor scheme, DEBUG ComposeApp XCFramework
+      # assembly, framework embed) to the consumer's canonical `fastlane ios build_ios` lane. The
+      # reusable flow stays project-agnostic — it never hardcodes a scheme/workspace, never runs the
+      # ambiguous `:shared:compileKotlin`, and never builds an unused RELEASE XCFramework. The
+      # settings-timeout override keeps `-showBuildSettings` from falsely timing out on the SwiftPM
+      # graph on a cold runner.
+      - name: fastlane ios build_ios (unsigned, debug)
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '120'
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '5'
+        run: bundle exec fastlane ios build_ios
 
   desktop:
     if: ${{ contains(inputs.platforms, 'desktop') }}
@@ -70,6 +110,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      # Was missing entirely: without setup-gradle this 3-OS matrix re-downloaded the whole
+      # dependency graph cold every run (the source of the intermittent Maven/plugin-portal 429s)
+      # and shared no build cache. Per-OS caches are keyed automatically by the action.
+      - uses: gradle/actions/setup-gradle@v4
       - name: Build Desktop distributable
         run: ./gradlew ":${{ inputs.desktop_package_name }}:createReleaseDistributable"
 
@@ -81,5 +125,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      # Was missing entirely — same cold-download / no-build-cache penalty as the desktop job above.
+      - uses: gradle/actions/setup-gradle@v4
       - name: Build Kotlin/JS distribution
         run: ./gradlew ":${{ inputs.web_package_name }}:jsBrowserDistribution"

--- a/.github/workflows/quality-gate-v2.yaml
+++ b/.github/workflows/quality-gate-v2.yaml
@@ -19,6 +19,13 @@ on:
       sbom_path:
         value: ${{ jobs.sbom.outputs.path }}
 
+# Cancel a superseded run instead of letting five fresh jobs pile on and hold runners (the dev-team
+# "runs in bunches, grabs many runners" report). Scoped per caller repo+ref so unrelated callers on
+# the same branch name never cancel each other.
+concurrency:
+  group: quality-gate-v2-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
     name: Spotless
@@ -27,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew spotlessCheck
 
   static-analysis:
@@ -36,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew detekt
       - uses: actions/upload-artifact@v4
         if: always()
@@ -48,6 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew dependencyGuard
 
   coverage:
@@ -59,6 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - name: Run tests + Kover XML report
         run: ./gradlew koverXmlReport
       - name: Compute coverage + enforce threshold
@@ -90,6 +101,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - name: Generate SBOM via cyclonedx-gradle-plugin
         id: gen
         run: |

--- a/.github/workflows/security-scan-v2.yaml
+++ b/.github/workflows/security-scan-v2.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with: { distribution: zulu, java-version: '${{ inputs.java-version }}' }
+      - uses: gradle/actions/setup-gradle@v4
       - id: gen
         run: |
           ./gradlew cyclonedxBom -PcyclonedxOutputFormat="${{ inputs.sbom_format }}"

--- a/README.md
+++ b/README.md
@@ -16,17 +16,35 @@
 
 ## 🆕 v2 surface (since v1.0.17)
 
-[`.github/workflows/v2/`](./.github/workflows/v2/) — a redesigned, opt-in workflow surface featuring:
+The **`*-v2.yaml`** workflows (flattened from the old `v2/` subdir) are a redesigned, opt-in surface. v2 is a **3-tier repository chain** — the orchestrator here fans out to dedicated per-platform repos:
 
-- **Uniform 3-stage promotion ladder** across Android / iOS / macOS / Desktop / Web (internal → beta → production)
+```
+Consumer (kmp-project-template + forks)              Tier 1 — thin wrapper (release-multi-platform.yml)
+    └─ uses openMF/mifos-x-actionhub/.github/workflows/*-v2.yaml@v1.0.X →
+openMF/mifos-x-actionhub  (THIS REPO)                Tier 2 — orchestrator (*-v2.yaml)
+    └─ uses openMF/mifos-x-actionhub-publish-*-kmp@v2.0.X →
+openMF/mifos-x-actionhub-publish-{android,           Tier 3 — per-platform build / sign / publish ladders
+                    apple,desktop,web}-kmp
+```
+
+**Orchestrator workflows** (`.github/workflows/*-v2.yaml`):
+
+- **Uniform 3-stage promotion ladder** across Android / iOS / macOS / Desktop / Web (internal → beta → production) — `release-multi-platform-v2.yaml` + per-platform `release-{android,apple,desktop,web}-v2.yaml`
 - **Approval gates** via GHA `environment:` protection rules (consumer-configured)
-- **Supersede semantics** (`concurrency.cancel-in-progress: true`) — new release cancels pending approvals
-- **Auto-tag + auto-release** (`v2/tag-weekly-release.yaml`, `v2/tag-monthly-release.yaml`) — adopting the `mifos-pay` cron pattern
-- **NEW capabilities** absent in v1: `v2/rollback.yaml`, `v2/security-scan.yaml`, `v2/deployment-status.yaml`, `v2/release-notes-generate.yaml`
+- **Supersede semantics** (`concurrency.cancel-in-progress: true`) — a new release cancels pending approvals
+- **Auto-tag + auto-release** — `tag-weekly-release-v2.yaml`, `tag-monthly-release-v2.yaml`
+- **NEW capabilities** absent in v1 — `rollback-v2.yaml`, `security-scan-v2.yaml`, `deployment-status-v2.yaml`, `release-notes-generate-v2.yaml`, `quality-gate-v2.yaml`, `pr-check-v2.yaml`
 
-**v1 is unchanged.** Pinned consumers at `@v1.0.16` continue working without migration. Opt-in to v2 by referencing `.github/workflows/v2/*@v1.0.17+`.
+**Tier-3 per-platform repositories** — the actual build/sign/publish logic lives in dedicated repos, pinned per-workflow at `@v2.0.X`:
 
-📖 See [`.github/workflows/v2/README.md`](./.github/workflows/v2/README.md) for the full v2 file index, migration table, and consumer usage examples.
+- [`mifos-x-actionhub-publish-android-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-android-kmp)
+- [`mifos-x-actionhub-publish-apple-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-apple-kmp) — iOS + macOS
+- [`mifos-x-actionhub-publish-desktop-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-desktop-kmp)
+- [`mifos-x-actionhub-publish-web-kmp`](https://github.com/openMF/mifos-x-actionhub-publish-web-kmp)
+
+**v1 is unchanged.** Pinned consumers at `@v1.0.16` continue working without migration. Opt-in to v2 by referencing `.github/workflows/*-v2.yaml@v1.0.17+`.
+
+📖 [`.github/V2_GUIDE.md`](./.github/V2_GUIDE.md) — canonical secret schema + v2 usage · [`CONTRIBUTING.md`](./CONTRIBUTING.md) — which repo owns which change · [`PLATFORM_REGISTRY.yaml`](./PLATFORM_REGISTRY.yaml) — the per-platform repo registry.
 
 ---
 


### PR DESCRIPTION
## Summary

Re-homes the build-time / CI improvements from the (main-based, now-conflicting) PR #82 onto the new
default branch **`dev`**. Cuts PR build time and eliminates the intermittent Maven/plugin-portal **429s**
by giving every Gradle-running job a warm cache, modernizes the iOS PR-check job, and stops superseded
runs from holding runners. Motivated by the dev-team report: *"pr-check-v2 runs > 45 min and grabs many
runners, holds them > 50 min."*

## Changes

**`pr-check-v2.yaml`**
- **iOS job modernized**: `macos-14 → macos-26` (input `macos_runner`), drop slow `maxim-lobanov/setup-xcode@15.2`
  for an instant `xcode-select` of Xcode 26.5 (input `xcode_version`, guarded fallback), add `~/.konan` +
  SwiftPM caches, and delegate to the consumer's canonical `fastlane ios build_ios` lane (no hardcoded
  scheme/workspace, no unused RELEASE XCFramework).
- `desktop` (3-OS matrix) and `web` had **no `setup-gradle` at all** — every run re-downloaded the whole
  dependency graph cold (the 429 source) and shared no build cache. Added `setup-gradle@v4` to both.
- Added workflow-level `concurrency: cancel-in-progress`; bumped `android`/`ios` `setup-gradle@v3 → @v4`.

**`quality-gate-v2.yaml`**
- Added `concurrency: cancel-in-progress` (had none) + `setup-gradle@v4` to all 5 jobs (each was a cold build).

**`security-scan-v2.yaml`**
- Added `setup-gradle@v4` to the SBOM job.

**`README.md`**
- v2-surface section refresh (flattened `*-v2.yaml` paths, 3-tier chain, Tier-3 publish-* links).

## Scope notes
- Deliberately **excludes** `release-multi-platform-v2.yaml` (its content diverges between the `main` and
  `dev` histories — the branch's edits were against `main`'s copy and must not clobber `dev`'s) and
  `tests/chain-contract.sh` (its T42 fix was for `main`'s red CI and couples to that orchestrator file).
  Both are `main`-history-specific and not needed on `dev`.
- Caching writes on the default branch and restores on PRs (setup-gradle default), so the biggest wins land
  once `dev` populates the cache; the 429 elimination is immediate.
- Supersedes the main-based draft PR #82.
