### PR TITLE
fix(release): tag-authoritative version floor (Releases lag tags → next is v1.0.62)

### DIFF
--- a/.github/workflows/promote-dev-to-main-release.yaml
+++ b/.github/workflows/promote-dev-to-main-release.yaml
@@ -8,9 +8,11 @@
 #   main — the released line. Consumers pin the `@vX.Y.Z` tags cut FROM main.
 #
 # VERSIONING (dogfoods the org's shared actions)
-#   • Resolve  → MobileByteLabs/mbl-actionhub-resolve-version (github-releases mode).
-#                GitHub Releases on `main` are the source of truth; Maven checks are off
-#                because the actionhub is not a Maven artifact.
+#   • Resolve  → MobileByteLabs/mbl-actionhub-resolve-version (github-releases mode) for the
+#                bump intent + explicit-override, THEN floored at the highest existing git tag
+#                (Releases can lag tags — currently Releases stop at v1.0.47 while tags reach
+#                v1.0.61 — so tags are the authoritative uniqueness source). Maven checks off
+#                (the actionhub is not a Maven artifact).
 #   • Bump     → MobileByteLabs/mbl-actionhub-bump-version opens a PR on dev advancing the
 #                human-visible `version.properties` marker after the release.
 #   The dev→main promotion itself is bespoke (no action covers a two-unrelated-histories
@@ -83,23 +85,43 @@ jobs:
           verify-against-maven: 'false'
           tag-pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
 
+      # Tag-authoritative floor. GitHub Releases can lag tags (in this repo, Releases stop at
+      # v1.0.47 while tags run to v1.0.61), so the resolver's Releases-based proposal may
+      # undershoot. Floor the version at latest-tag+bump and take the higher of that vs. the
+      # resolver's intent — guaranteeing the release never collides with / regresses below an
+      # existing tag. Once a release publishes tag+Release together, the two converge and the
+      # resolver becomes authoritative on its own.
       - name: Normalize + guard version
         id: ver
         run: |
           set -euo pipefail
-          RAW='${{ steps.resolve.outputs.version }}'
-          NUM=${RAW#v}
-          echo "$NUM" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::resolver returned non-semver: '$RAW'"; exit 1; }
-          TAG="v$NUM"
           git fetch --tags --force --quiet
+          RAW='${{ steps.resolve.outputs.version }}'
+          RNUM=${RAW#v}
+          echo "$RNUM" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::resolver returned non-semver: '$RAW'"; exit 1; }
+          if [ -n "${{ inputs.release_version }}" ]; then
+            # Explicit override: honor exactly; collision-guard only.
+            NUM=$RNUM
+          else
+            LT=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1); LT=${LT#v}; LT=${LT:-0.0.0}
+            a=${LT%%.*}; r=${LT#*.}; b=${r%%.*}; c=${r##*.}
+            case "${{ inputs.bump }}" in
+              major) FLOOR="$((a+1)).0.0" ;;
+              minor) FLOOR="${a}.$((b+1)).0" ;;
+              *)     FLOOR="${a}.${b}.$((c+1))" ;;
+            esac
+            NUM=$(printf '%s\n%s\n' "$RNUM" "$FLOOR" | sort -V | tail -1)
+          fi
+          TAG="v$NUM"
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "::error::tag $TAG already exists (resolver source: ${{ steps.resolve.outputs.source }}). Pass a higher release_version."; exit 1
+            echo "::error::tag $TAG already exists — pass a higher release_version."; exit 1
           fi
           echo "num=$NUM" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           {
             echo "## Release plan"
-            echo "- resolver source: \`${{ steps.resolve.outputs.source }}\`  current: \`${{ steps.resolve.outputs.current }}\`"
+            echo "- resolver: \`${{ steps.resolve.outputs.version }}\` (source \`${{ steps.resolve.outputs.source }}\`, current \`${{ steps.resolve.outputs.current }}\`)"
+            echo "- highest existing tag floored the result (Releases lag tags in this repo)"
             echo "- **this release: \`$TAG\`**"
             echo "- dry run: \`${{ inputs.dry_run }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-dev-to-main-release.yaml
+++ b/.github/workflows/promote-dev-to-main-release.yaml
@@ -5,20 +5,26 @@
 #
 # BRANCH MODEL
 #   dev  — development (default branch). All PRs merge here.
-#   main — the released line. Consumers pin `@vX.Y.Z` tags cut FROM main.
+#   main — the released line. Consumers pin the `@vX.Y.Z` tags cut FROM main.
 #
-# "Rebase main with dev" here means: main's TREE is set to dev's tree exactly, via a
-# merge commit whose parents are [old-main, dev]. This is:
-#   • conflict-free      (tree is copied, never 3-way merged),
-#   • non-destructive    (old-main is a parent → fast-forward push, no --force),
-#   • history-linked     (dev becomes an ancestor of main; future promotes stay clean),
-#   • correct for the current state where main and dev are UNRELATED histories
-#     (the copy-tree approach needs no common ancestor).
+# VERSIONING (dogfoods the org's shared actions)
+#   • Resolve  → MobileByteLabs/mbl-actionhub-resolve-version (github-releases mode).
+#                GitHub Releases on `main` are the source of truth; Maven checks are off
+#                because the actionhub is not a Maven artifact.
+#   • Bump     → MobileByteLabs/mbl-actionhub-bump-version opens a PR on dev advancing the
+#                human-visible `version.properties` marker after the release.
+#   The dev→main promotion itself is bespoke (no action covers a two-unrelated-histories
+#   tree promotion) — see the "Promote" step.
+#
+# "Rebase main with dev" == set main's TREE to dev's tree via a merge commit
+# (`git commit-tree <dev-tree> -p main -p dev`): conflict-free, non-force (old main is a
+# parent → fast-forward push), history-linked, and valid even though main and dev are
+# currently unrelated histories.
 #
 # TOKEN
-#   Promoting dev's `.github/workflows/**` changes onto main requires a PAT with the
-#   `workflow` scope — GITHUB_TOKEN is forbidden from writing workflow files. Store it as
-#   the `RELEASE_TOKEN` secret. Falls back to github.token when no workflow files change.
+#   Promoting dev's `.github/workflows/**` onto main requires a PAT with the `workflow`
+#   scope (GITHUB_TOKEN may not write workflow files). Store it as `RELEASE_TOKEN`; the
+#   workflow falls back to github.token when a release carries no workflow-file changes.
 name: Release · Promote dev → main
 
 on:
@@ -30,18 +36,18 @@ on:
         options: [patch, minor, major]
         default: patch
       release_version:
-        description: 'Explicit version e.g. v1.0.30 (overrides bump; leave blank to auto-compute)'
+        description: 'Explicit version e.g. v1.0.30 (overrides bump; blank = auto)'
         type: string
         required: false
       dry_run:
-        description: 'Compute + log only — no push, tag, release, or bump'
+        description: 'Resolve + log only — no push, tag, release, or bump'
         type: boolean
         default: false
 
 permissions:
   contents: write
+  pull-requests: write
 
-# One release at a time; never cancel a release mid-flight.
 concurrency:
   group: promote-dev-to-main
   cancel-in-progress: false
@@ -63,41 +69,38 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Compute release + next version
+      # Source of truth = GitHub Releases on this repo. Maven verification disabled (not a
+      # Maven artifact); group-id/artifact-id are required inputs but unused in this mode.
+      - name: Resolve release version
+        id: resolve
+        uses: MobileByteLabs/mbl-actionhub-resolve-version@v1.2.0
+        with:
+          group-id: openMF
+          artifact-id: mifos-x-actionhub
+          version-source: github-releases
+          bump: ${{ inputs.bump }}
+          version: ${{ inputs.release_version }}
+          verify-against-maven: 'false'
+          tag-pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+
+      - name: Normalize + guard version
         id: ver
         run: |
           set -euo pipefail
+          RAW='${{ steps.resolve.outputs.version }}'
+          NUM=${RAW#v}
+          echo "$NUM" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::resolver returned non-semver: '$RAW'"; exit 1; }
+          TAG="v$NUM"
           git fetch --tags --force --quiet
-          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1)
-          LATEST=${LATEST:-v1.0.0}
-          if [ -n "${{ inputs.release_version }}" ]; then
-            REL="${{ inputs.release_version }}"
-            case "$REL" in v*) ;; *) REL="v$REL" ;; esac
-          else
-            ver=${LATEST#v}
-            MA=${ver%%.*}; rest=${ver#*.}; MI=${rest%%.*}; PA=${rest##*.}
-            case "${{ inputs.bump }}" in
-              major) MA=$((MA+1)); MI=0; PA=0 ;;
-              minor) MI=$((MI+1)); PA=0 ;;
-              *)     PA=$((PA+1)) ;;
-            esac
-            REL="v${MA}.${MI}.${PA}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::tag $TAG already exists (resolver source: ${{ steps.resolve.outputs.source }}). Pass a higher release_version."; exit 1
           fi
-          echo "$REL" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::not semver: $REL"; exit 1; }
-          if git rev-parse -q --verify "refs/tags/$REL" >/dev/null; then
-            echo "::error::tag $REL already exists — pick a higher version"; exit 1
-          fi
-          rv=${REL#v}; a=${rv%%.*}; r=${rv#*.}; b=${r%%.*}; c=${r##*.}
-          NEXT="v${a}.${b}.$((c+1))"
-          {
-            echo "release=$REL"
-            echo "next=$NEXT"
-          } >> "$GITHUB_OUTPUT"
+          echo "num=$NUM" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           {
             echo "## Release plan"
-            echo "- previous released tag: \`$LATEST\`"
-            echo "- **this release: \`$REL\`**"
-            echo "- next dev version: \`$NEXT\`"
+            echo "- resolver source: \`${{ steps.resolve.outputs.source }}\`  current: \`${{ steps.resolve.outputs.current }}\`"
+            echo "- **this release: \`$TAG\`**"
             echo "- dry run: \`${{ inputs.dry_run }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -116,7 +119,7 @@ jobs:
               NEW=$MAIN
             else
               NEW=$(git commit-tree "$TREE" -p "$MAIN" -p "$DEV" \
-                    -m "release(${{ steps.ver.outputs.release }}): promote dev → main")
+                    -m "release(${{ steps.ver.outputs.tag }}): promote dev → main")
             fi
           else
             NEW=$DEV
@@ -130,23 +133,22 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
         run: |
           set -euo pipefail
-          REL='${{ steps.ver.outputs.release }}'
-          git tag -a "$REL" "$MAIN_SHA" -m "$REL"
-          git push origin "refs/tags/$REL"
-          gh release create "$REL" --verify-tag --title "$REL" --generate-notes --latest
-          echo "released **$REL** on main @ \`$MAIN_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+          TAG='${{ steps.ver.outputs.tag }}'
+          git tag -a "$TAG" "$MAIN_SHA" -m "$TAG"
+          git push origin "refs/tags/$TAG"
+          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes --latest
+          echo "released **$TAG** on main @ \`$MAIN_SHA\`" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Open next dev version (bump VERSION on dev)
+      # Post-release: PR on dev advancing the human-visible marker to the next patch.
+      # SoT remains the Releases above; this file is not read back by the resolver.
+      - name: Bump next dev version (PR on dev)
         if: ${{ inputs.dry_run == false }}
-        run: |
-          set -euo pipefail
-          git fetch origin dev --quiet
-          git checkout -B dev origin/dev
-          echo "${{ steps.ver.outputs.next }}" > VERSION
-          git add VERSION
-          if git diff --cached --quiet; then
-            echo "VERSION already ${{ steps.ver.outputs.next }} — no bump commit."
-          else
-            git commit -m "chore(release): open ${{ steps.ver.outputs.next }} development cycle [skip ci]"
-            git push origin dev
-          fi
+        uses: MobileByteLabs/mbl-actionhub-bump-version@v1.6.0
+        with:
+          published-version: ${{ steps.ver.outputs.num }}
+          properties-path: version.properties
+          properties-key: actionhub.version
+          bump-type: patch
+          base-branch: dev
+          auto-merge: 'true'
+          github-token: ${{ secrets.RELEASE_TOKEN || github.token }}

--- a/.github/workflows/promote-dev-to-main-release.yaml
+++ b/.github/workflows/promote-dev-to-main-release.yaml
@@ -1,0 +1,152 @@
+# .github/workflows/promote-dev-to-main-release.yaml
+#
+# Manually-triggered release: promote dev → main, tag it, cut a GitHub Release,
+# and open the next in-development version on dev.
+#
+# BRANCH MODEL
+#   dev  — development (default branch). All PRs merge here.
+#   main — the released line. Consumers pin `@vX.Y.Z` tags cut FROM main.
+#
+# "Rebase main with dev" here means: main's TREE is set to dev's tree exactly, via a
+# merge commit whose parents are [old-main, dev]. This is:
+#   • conflict-free      (tree is copied, never 3-way merged),
+#   • non-destructive    (old-main is a parent → fast-forward push, no --force),
+#   • history-linked     (dev becomes an ancestor of main; future promotes stay clean),
+#   • correct for the current state where main and dev are UNRELATED histories
+#     (the copy-tree approach needs no common ancestor).
+#
+# TOKEN
+#   Promoting dev's `.github/workflows/**` changes onto main requires a PAT with the
+#   `workflow` scope — GITHUB_TOKEN is forbidden from writing workflow files. Store it as
+#   the `RELEASE_TOKEN` secret. Falls back to github.token when no workflow files change.
+name: Release · Promote dev → main
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver bump for this release (ignored if release_version is set)'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+      release_version:
+        description: 'Explicit version e.g. v1.0.30 (overrides bump; leave blank to auto-compute)'
+        type: string
+        required: false
+      dry_run:
+        description: 'Compute + log only — no push, tag, release, or bump'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+# One release at a time; never cancel a release mid-flight.
+concurrency:
+  group: promote-dev-to-main
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dev (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+          persist-credentials: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute release + next version
+        id: ver
+        run: |
+          set -euo pipefail
+          git fetch --tags --force --quiet
+          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1)
+          LATEST=${LATEST:-v1.0.0}
+          if [ -n "${{ inputs.release_version }}" ]; then
+            REL="${{ inputs.release_version }}"
+            case "$REL" in v*) ;; *) REL="v$REL" ;; esac
+          else
+            ver=${LATEST#v}
+            MA=${ver%%.*}; rest=${ver#*.}; MI=${rest%%.*}; PA=${rest##*.}
+            case "${{ inputs.bump }}" in
+              major) MA=$((MA+1)); MI=0; PA=0 ;;
+              minor) MI=$((MI+1)); PA=0 ;;
+              *)     PA=$((PA+1)) ;;
+            esac
+            REL="v${MA}.${MI}.${PA}"
+          fi
+          echo "$REL" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::not semver: $REL"; exit 1; }
+          if git rev-parse -q --verify "refs/tags/$REL" >/dev/null; then
+            echo "::error::tag $REL already exists — pick a higher version"; exit 1
+          fi
+          rv=${REL#v}; a=${rv%%.*}; r=${rv#*.}; b=${r%%.*}; c=${r##*.}
+          NEXT="v${a}.${b}.$((c+1))"
+          {
+            echo "release=$REL"
+            echo "next=$NEXT"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Release plan"
+            echo "- previous released tag: \`$LATEST\`"
+            echo "- **this release: \`$REL\`**"
+            echo "- next dev version: \`$NEXT\`"
+            echo "- dry run: \`${{ inputs.dry_run }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Promote dev → main  (main tree := dev tree, non-force, history-linked)
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          set -euo pipefail
+          git fetch origin dev --quiet
+          DEV=$(git rev-parse origin/dev)
+          TREE=$(git rev-parse "$DEV^{tree}")
+          if git ls-remote --exit-code --heads origin main >/dev/null 2>&1; then
+            git fetch origin main --quiet
+            MAIN=$(git rev-parse origin/main)
+            if [ "$(git rev-parse "$MAIN^{tree}")" = "$TREE" ]; then
+              echo "main already carries dev's tree — nothing to promote."
+              NEW=$MAIN
+            else
+              NEW=$(git commit-tree "$TREE" -p "$MAIN" -p "$DEV" \
+                    -m "release(${{ steps.ver.outputs.release }}): promote dev → main")
+            fi
+          else
+            NEW=$DEV
+          fi
+          git push origin "$NEW:refs/heads/main"
+          echo "MAIN_SHA=$NEW" >> "$GITHUB_ENV"
+
+      - name: Tag + GitHub Release on main
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          REL='${{ steps.ver.outputs.release }}'
+          git tag -a "$REL" "$MAIN_SHA" -m "$REL"
+          git push origin "refs/tags/$REL"
+          gh release create "$REL" --verify-tag --title "$REL" --generate-notes --latest
+          echo "released **$REL** on main @ \`$MAIN_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open next dev version (bump VERSION on dev)
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          set -euo pipefail
+          git fetch origin dev --quiet
+          git checkout -B dev origin/dev
+          echo "${{ steps.ver.outputs.next }}" > VERSION
+          git add VERSION
+          if git diff --cached --quiet; then
+            echo "VERSION already ${{ steps.ver.outputs.next }} — no bump commit."
+          else
+            git commit -m "chore(release): open ${{ steps.ver.outputs.next }} development cycle [skip ci]"
+            git push origin dev
+          fi

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,7 @@
+# In-development version marker (human-visible).
+#
+# Source of truth for RELEASED versions is the GitHub Releases / vX.Y.Z tags on `main`.
+# This file mirrors the next dev target and is advanced post-release by
+# MobileByteLabs/mbl-actionhub-bump-version (opened as a PR on dev). It is NOT read back
+# by the release resolver, so it can never drift the actual release numbering.
+actionhub.version=1.0.30

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,8 @@
 # In-development version marker (human-visible).
 #
-# Source of truth for RELEASED versions is the GitHub Releases / vX.Y.Z tags on `main`.
-# This file mirrors the next dev target and is advanced post-release by
-# MobileByteLabs/mbl-actionhub-bump-version (opened as a PR on dev). It is NOT read back
-# by the release resolver, so it can never drift the actual release numbering.
-actionhub.version=1.0.30
+# Source of truth for RELEASED versions is the vX.Y.Z tags on `main` (git enforces tag
+# uniqueness, and tags run ahead of GitHub Releases in this repo). This file mirrors the
+# next dev target and is advanced post-release by MobileByteLabs/mbl-actionhub-bump-version
+# (opened as a PR on dev). It is NOT read back by the release resolver, so it can never
+# drift the actual release numbering.
+actionhub.version=1.0.62


### PR DESCRIPTION
## Summary

Follow-up fix to the release workflow merged in #84. A `dry_run` of that workflow surfaced a real
repo-state issue: **GitHub Releases lag tags badly** — the latest *Release* is `v1.0.47` (and `latest`
is even flagged on `v1.0.22`), while tags run to **`v1.0.61`** (tags `v1.0.40`–`v1.0.61` have no
Release). So `resolve-version`'s `github-releases` mode undershot to `v1.0.48`, which already exists as
a tag — the workflow's guard caught it and stopped safely.

## Fix

Make the normalize step **tag-authoritative**: floor the version at `latest-tag + bump` and take the
higher of that vs. the resolver's proposal. This:
- guarantees the release never collides with / regresses below an existing tag (→ next release is
  correctly **`v1.0.62`**),
- keeps `resolve-version` for its bump intent + explicit-`release_version` override + metadata,
- **self-heals**: once the first release publishes `v1.0.62` as *both* tag and Release, Releases catch
  up to tags and the resolver becomes authoritative on its own.

Also seeds `version.properties = 1.0.62` (the next dev target).

## After merge
Re-run **Release · Promote dev → main** with `dry_run: true` — it should now report **`v1.0.62`**.
