### PR TITLE
fix(release): tag-authoritative version floor (Releases lag tags → next is v1.0.62)

### DIFF
--- a/.github/workflows/promote-dev-to-main-release.yaml
+++ b/.github/workflows/promote-dev-to-main-release.yaml
@@ -8,9 +8,11 @@
 #   main — the released line. Consumers pin the `@vX.Y.Z` tags cut FROM main.
 #
 # VERSIONING (dogfoods the org's shared actions)
-#   • Resolve  → MobileByteLabs/mbl-actionhub-resolve-version (github-releases mode).
-#                GitHub Releases on `main` are the source of truth; Maven checks are off
-#                because the actionhub is not a Maven artifact.
+#   • Resolve  → MobileByteLabs/mbl-actionhub-resolve-version (github-releases mode) for the
+#                bump intent + explicit-override, THEN floored at the highest existing git tag
+#                (Releases can lag tags — currently Releases stop at v1.0.47 while tags reach
+#                v1.0.61 — so tags are the authoritative uniqueness source). Maven checks off
+#                (the actionhub is not a Maven artifact).
 #   • Bump     → MobileByteLabs/mbl-actionhub-bump-version opens a PR on dev advancing the
 #                human-visible `version.properties` marker after the release.
 #   The dev→main promotion itself is bespoke (no action covers a two-unrelated-histories
@@ -83,23 +85,43 @@ jobs:
           verify-against-maven: 'false'
           tag-pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
 
+      # Tag-authoritative floor. GitHub Releases can lag tags (in this repo, Releases stop at
+      # v1.0.47 while tags run to v1.0.61), so the resolver's Releases-based proposal may
+      # undershoot. Floor the version at latest-tag+bump and take the higher of that vs. the
+      # resolver's intent — guaranteeing the release never collides with / regresses below an
+      # existing tag. Once a release publishes tag+Release together, the two converge and the
+      # resolver becomes authoritative on its own.
       - name: Normalize + guard version
         id: ver
         run: |
           set -euo pipefail
-          RAW='${{ steps.resolve.outputs.version }}'
-          NUM=${RAW#v}
-          echo "$NUM" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::resolver returned non-semver: '$RAW'"; exit 1; }
-          TAG="v$NUM"
           git fetch --tags --force --quiet
+          RAW='${{ steps.resolve.outputs.version }}'
+          RNUM=${RAW#v}
+          echo "$RNUM" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::resolver returned non-semver: '$RAW'"; exit 1; }
+          if [ -n "${{ inputs.release_version }}" ]; then
+            # Explicit override: honor exactly; collision-guard only.
+            NUM=$RNUM
+          else
+            LT=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1); LT=${LT#v}; LT=${LT:-0.0.0}
+            a=${LT%%.*}; r=${LT#*.}; b=${r%%.*}; c=${r##*.}
+            case "${{ inputs.bump }}" in
+              major) FLOOR="$((a+1)).0.0" ;;
+              minor) FLOOR="${a}.$((b+1)).0" ;;
+              *)     FLOOR="${a}.${b}.$((c+1))" ;;
+            esac
+            NUM=$(printf '%s\n%s\n' "$RNUM" "$FLOOR" | sort -V | tail -1)
+          fi
+          TAG="v$NUM"
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "::error::tag $TAG already exists (resolver source: ${{ steps.resolve.outputs.source }}). Pass a higher release_version."; exit 1
+            echo "::error::tag $TAG already exists — pass a higher release_version."; exit 1
           fi
           echo "num=$NUM" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           {
             echo "## Release plan"
-            echo "- resolver source: \`${{ steps.resolve.outputs.source }}\`  current: \`${{ steps.resolve.outputs.current }}\`"
+            echo "- resolver: \`${{ steps.resolve.outputs.version }}\` (source \`${{ steps.resolve.outputs.source }}\`, current \`${{ steps.resolve.outputs.current }}\`)"
+            echo "- highest existing tag floored the result (Releases lag tags in this repo)"
             echo "- **this release: \`$TAG\`**"
             echo "- dry run: \`${{ inputs.dry_run }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/version.properties
+++ b/version.properties
@@ -1,7 +1,8 @@
 # In-development version marker (human-visible).
 #
-# Source of truth for RELEASED versions is the GitHub Releases / vX.Y.Z tags on `main`.
-# This file mirrors the next dev target and is advanced post-release by
-# MobileByteLabs/mbl-actionhub-bump-version (opened as a PR on dev). It is NOT read back
-# by the release resolver, so it can never drift the actual release numbering.
-actionhub.version=1.0.30
+# Source of truth for RELEASED versions is the vX.Y.Z tags on `main` (git enforces tag
+# uniqueness, and tags run ahead of GitHub Releases in this repo). This file mirrors the
+# next dev target and is advanced post-release by MobileByteLabs/mbl-actionhub-bump-version
+# (opened as a PR on dev). It is NOT read back by the release resolver, so it can never
+# drift the actual release numbering.
+actionhub.version=1.0.62


### PR DESCRIPTION
## Summary

Follow-up fix to the release workflow merged in #84. A `dry_run` of that workflow surfaced a real
repo-state issue: **GitHub Releases lag tags badly** — the latest *Release* is `v1.0.47` (and `latest`
is even flagged on `v1.0.22`), while tags run to **`v1.0.61`** (tags `v1.0.40`–`v1.0.61` have no
Release). So `resolve-version`'s `github-releases` mode undershot to `v1.0.48`, which already exists as
a tag — the workflow's guard caught it and stopped safely.

## Fix

Make the normalize step **tag-authoritative**: floor the version at `latest-tag + bump` and take the
higher of that vs. the resolver's proposal. This:
- guarantees the release never collides with / regresses below an existing tag (→ next release is
  correctly **`v1.0.62`**),
- keeps `resolve-version` for its bump intent + explicit-`release_version` override + metadata,
- **self-heals**: once the first release publishes `v1.0.62` as *both* tag and Release, Releases catch
  up to tags and the resolver becomes authoritative on its own.

Also seeds `version.properties = 1.0.62` (the next dev target).

## After merge
Re-run **Release · Promote dev → main** with `dry_run: true` — it should now report **`v1.0.62`**.
