### PR TITLE
chore(version): bump actionhub.version to 1.0.63 (post-release)

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -5,4 +5,4 @@
 # next dev target and is advanced post-release by MobileByteLabs/mbl-actionhub-bump-version
 # (opened as a PR on dev). It is NOT read back by the release resolver, so it can never
 # drift the actual release numbering.
-actionhub.version=1.0.62
+actionhub.version=1.0.63


### PR DESCRIPTION
Auto-opened by [mbl-actionhub-bump-version](https://github.com/MobileByteLabs/mbl-actionhub-bump-version) after a successful release of `v1.0.62`.

- **Bump type:** `patch`
- **From:** `1.0.62` (just published)
- **To:** `1.0.63` (next release target)
- **File:** `version.properties` → `actionhub.version=1.0.63`

Sets the next sanity-check value so the next publish run can proceed (`1.0.63 > 1.0.62` on Maven Central).

If you want a different bump type (minor/major) for the next cycle, close this PR and bump manually.